### PR TITLE
Fix download links for apache-maven-{3.2.5,3.1.1,3.0.5}-src.tar.gz.asc.

### DIFF
--- a/content/xdoc/download.xml.vm
+++ b/content/xdoc/download.xml.vm
@@ -189,7 +189,7 @@ under the License.
               <td>Maven ${current32xVersion} (Source tar.gz)</td>
               <td><a href="[preferred]maven/maven-3/${current32xVersion}/source/apache-maven-${current32xVersion}-src.tar.gz">apache-maven-${current32xVersion}-src.tar.gz</a></td>
               <td><a href="http://www.apache.org/dist/maven/maven-3/${current32xVersion}/source/apache-maven-${current32xVersion}-src.tar.gz.md5">apache-maven-${current32xVersion}-src.tar.gz.md5</a></td>
-              <td><a href="http://www.apache.org/dist/maven/maven-2/${current32xVersion}/source/apache-maven-${current32xVersion}-src.tar.gz.asc">apache-maven-${current32xVersion}-src.tar.gz.asc</a></td>
+              <td><a href="http://www.apache.org/dist/maven/maven-3/${current32xVersion}/source/apache-maven-${current32xVersion}-src.tar.gz.asc">apache-maven-${current32xVersion}-src.tar.gz.asc</a></td>
             </tr>
             <tr>
               <td>Maven ${current32xVersion} (Source zip)</td>
@@ -245,7 +245,7 @@ under the License.
               <td>Maven ${current31xVersion} (Source tar.gz)</td>
               <td><a href="[preferred]maven/maven-3/${current31xVersion}/source/apache-maven-${current31xVersion}-src.tar.gz">apache-maven-${current31xVersion}-src.tar.gz</a></td>
               <td><a href="http://www.apache.org/dist/maven/maven-3/${current31xVersion}/source/apache-maven-${current31xVersion}-src.tar.gz.md5">apache-maven-${current31xVersion}-src.tar.gz.md5</a></td>
-              <td><a href="http://www.apache.org/dist/maven/maven-2/${current31xVersion}/source/apache-maven-${current31xVersion}-src.tar.gz.asc">apache-maven-${current31xVersion}-src.tar.gz.asc</a></td>
+              <td><a href="http://www.apache.org/dist/maven/maven-3/${current31xVersion}/source/apache-maven-${current31xVersion}-src.tar.gz.asc">apache-maven-${current31xVersion}-src.tar.gz.asc</a></td>
             </tr>
             <tr>
               <td>Maven ${current31xVersion} (Source zip)</td>
@@ -299,7 +299,7 @@ under the License.
               <td>Maven ${current30xVersion} (Source tar.gz)</td>
               <td><a href="[preferred]maven/maven-3/${current30xVersion}/source/apache-maven-${current30xVersion}-src.tar.gz">apache-maven-${current30xVersion}-src.tar.gz</a></td>
               <td><a href="http://www.apache.org/dist/maven/maven-3/${current30xVersion}/source/apache-maven-${current30xVersion}-src.tar.gz.md5">apache-maven-${current30xVersion}-src.tar.gz.md5</a></td>
-              <td><a href="http://www.apache.org/dist/maven/maven-2/${current30xVersion}/source/apache-maven-${current30xVersion}-src.tar.gz.asc">apache-maven-${current30xVersion}-src.tar.gz.asc</a></td>
+              <td><a href="http://www.apache.org/dist/maven/maven-3/${current30xVersion}/source/apache-maven-${current30xVersion}-src.tar.gz.asc">apache-maven-${current30xVersion}-src.tar.gz.asc</a></td>
             </tr>
             <tr>
               <td>Maven ${current30xVersion} (Source zip)</td>


### PR DESCRIPTION
Summary says it. Some links on the download page contain the `/maven-2/` path component, while that should be `/maven-3/`.