### PR TITLE
Fixed 2 links

### DIFF
--- a/content/markdown/code-quality-management.md
+++ b/content/markdown/code-quality-management.md
@@ -16,6 +16,6 @@ the Maven community:
 -   [Squale](http://www.squale.org/)
 -   [XRadar](http://xradar.sourceforge.net)
 
-[PMD]: https://maven.apache.org/plugns/maven-pmd-plugin/
-[Checkstyle]: https://maven.apache.org/plugns/maven-checkstyle-plugin/
+[PMD]: https://maven.apache.org/plugins/maven-pmd-plugin/
+[Checkstyle]: https://maven.apache.org/plugins/maven-checkstyle-plugin/
 [JDepend]: https://mojohaus.org/jdepend-maven-plugin/


### PR DESCRIPTION
an "i" was missing in the CMD and Checkstyle maven plugin links