### PR TITLE
Fix broken links using archive.org

### DIFF
--- a/content/xdoc/articles.xml
+++ b/content/xdoc/articles.xml
@@ -316,31 +316,31 @@ Eric Redmond)
             <td>5 December 2005</td>
           </tr>
           <tr>
-            <td><a href="http://www.developer.com/open/article.php/10930_3552026_1">Taking the Maven 2 Plunge</a></td>
+            <td><a href="https://web.archive.org/web/20051127014056/http://www.developer.com/open/article.php/10930_3552026_1">Taking the Maven 2 Plunge</a></td>
             <td></td>
             <td>David DeWolf</td>
             <td>1 October 2005</td>
           </tr>
           <tr>
-            <td><a href="http://www.onjava.com/pub/a/onjava/2005/09/07/maven.html">Building J2EE Projects with Maven</a></td>
+            <td><a href="https://web.archive.org/web/20051228123436/http://www.onjava.com/pub/a/onjava/2005/09/07/maven.html">Building J2EE Projects with Maven</a></td>
             <td>OnJava</td>
             <td>Vincent Massol</td>
             <td>7 September 2005</td>
           </tr>
           <tr>
-            <td><a href="http://www-128.ibm.com/developerworks/opensource/library/os-maven/index.html">Exploiting Maven in Eclipse</a></td>
+            <td><a href="https://web.archive.org/web/20051212060839/http://www-128.ibm.com/developerworks/opensource/library/os-maven/index.html">Exploiting Maven in Eclipse</a></td>
             <td>developerWorks</td>
             <td>Gilles Dodinet</td>
             <td>24 May 2005</td>
           </tr>
           <tr>
-            <td><a href="http://www-128.ibm.com/developerworks/websphere/library/techarticles/0503_boog/0503_boog.html?ca=dgr-lnxw09Maven">Managing WebSphere Portal V5.1 projects with Apache Maven and Rational Application Developer 6.0</a></td>
+            <td><a href="https://web.archive.org/web/20051206214359/http://www-128.ibm.com/developerworks/websphere/library/techarticles/0503_boog/0503_boog.html?ca=dgr-lnxw09Maven">Managing WebSphere Portal V5.1 projects with Apache Maven and Rational Application Developer 6.0</a></td>
             <td>developerWorks</td>
             <td>Hinrich Boog</td>
             <td>30 March 2005</td>
           </tr>
           <tr>
-            <td><a href="http://www.oracle.com/technology/pub/articles/masterj2ee/j2ee_wk2.html">Master and Commander by Julien Dubois</a></td>
+            <td><a href="https://web.archive.org/web/20041217085616/http://www.oracle.com/technology/pub/articles/masterj2ee/j2ee_wk2.html">Master and Commander by Julien Dubois</a></td>
             <td>Oracle</td>
             <td>Julien Dubois</td>
             <td>November 2004</td>
@@ -358,26 +358,26 @@ Eric Redmond)
             <td>15 July 2004</td>
           </tr>
           <tr>
-            <td><a href="http://www.onjava.com/pub/a/onjava/2004/03/17/maven.html">Extending Maven Through Plugins by Eric Pugh</a></td>
+            <td><a href="https://web.archive.org/web/20160809061511/http://www.onjava.com/pub/a/onjava/2004/03/17/maven.html">Extending Maven Through Plugins by Eric Pugh</a></td>
             <td>OnJava</td>
             <td>Eric Pugh</td>
             <td>17 March 2004</td>
           </tr>
 
           <tr>
-            <td><a href="http://wiki.astrogrid.org/bin/view/Astrogrid/MakingWarWithMaven">How to get Maven to build your web service into a WAR on AstroGrid</a></td>
+            <td><a href="https://web.archive.org/web/20160611202944/http://wiki.astrogrid.org:80/bin/view/Astrogrid/MakingWarWithMaven">How to get Maven to build your web service into a WAR on AstroGrid</a></td>
             <td>Astrogrid</td>
             <td></td>
             <td></td>
           </tr>
           <tr>
-            <td><a href="http://wiki.astrogrid.org/bin/view/Astrogrid/MavenFAQ">Some Maven FAQs on AstroGrid</a></td>
+            <td><a href="https://web.archive.org/web/20160731000646/http://wiki.astrogrid.org/bin/view/Astrogrid/MavenFAQ">Some Maven FAQs on AstroGrid</a></td>
             <td>Astrogrid</td>
             <td></td>
             <td></td>
           </tr>
           <tr>
-            <td><a href="http://wiki.astrogrid.org/bin/view/Astrogrid/UsefulMavenNotes">Some Useful Maven Notes on AstroGrid</a></td>
+            <td><a href="https://web.archive.org/web/20160731002256/http://wiki.astrogrid.org/bin/view/Astrogrid/UsefulMavenNotes">Some Useful Maven Notes on AstroGrid</a></td>
             <td>Astrogrid</td>
             <td></td>
             <td></td>


### PR DESCRIPTION
Some old links are broken, we could use archive.org to still be able to see the content of the articles.