### PR TITLE
Broken link to password encryption guide

### DIFF
--- a/content/apt/guides/mini/guide-configuring-maven.apt
+++ b/content/apt/guides/mini/guide-configuring-maven.apt
@@ -163,7 +163,7 @@ export MAVEN_OPTS=-Dmaven.artifact.threads=3
 ** Security
 
   As of Maven 2.1.0+, you can encrypt passwords in your settings file, however you must first configure a master password. For more information on
-  both server passwords and the master password, see the {{{./guides/mini/guide-encryption.html}Guide to Password Encryption}}.
+  both server passwords and the master password, see the {{{.guide-encryption.html}Guide to Password Encryption}}.
 
 ** Toolchains
 

--- a/content/apt/guides/mini/guide-configuring-maven.apt
+++ b/content/apt/guides/mini/guide-configuring-maven.apt
@@ -163,9 +163,9 @@ export MAVEN_OPTS=-Dmaven.artifact.threads=3
 ** Security
 
   As of Maven 2.1.0+, you can encrypt passwords in your settings file, however you must first configure a master password. For more information on
-  both server passwords and the master password, see the {{{.guide-encryption.html}Guide to Password Encryption}}.
+  both server passwords and the master password, see the {{{./guide-encryption.html}Guide to Password Encryption}}.
 
 ** Toolchains
 
   As of Maven 2.0.9+, you can build a project using a specific version of JDK independent from the one Maven is running with.
-  For more information, see the {{{./guides/mini/guide-using-toolchains.html}Guide to Using Toolchains}}.
+  For more information, see the {{{./guide-using-toolchains.html}Guide to Using Toolchains}}.


### PR DESCRIPTION
Clicking "Guide to Password Encryption." currently incorrectly takes you to "https://maven.apache.org/guides/mini/guides/mini/guide-encryption.html".  I believe it intends to take you to "https://maven.apache.org/guides/mini/guide-encryption.html".   This commit should resolve this, but requires testing.