### PR TITLE
Fixes default flatten configuration in Install / Deploy in CI friendly documentation

### DIFF
--- a/content/markdown/maven-ci-friendly.md
+++ b/content/markdown/maven-ci-friendly.md
@@ -222,9 +222,10 @@ mvn -Drevision=2.7.8 -Dchangelist= clean package
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>flatten-maven-plugin</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
       <configuration>
         <updatePomFile>true</updatePomFile>
+        <flattenMode>resolveCiFriendliesOnly</flattenMode>
       </configuration>
       <executions>
         <execution>


### PR DESCRIPTION
The flatten-maven-plugin configuration shown in the example [maven-ci-friendly.md ## Install / Deploy](https://maven.apache.org/maven-ci-friendly.html#Install_.2F_Deploy) may lead to unusable pom for consumers. The configuration should use the following mode `<flattenMode>resolveCiFriendliesOnly</flattenMode>` by default.

At this time this `resolveCiFriendliesOnly` mode do not however appear in the [official doc](https://www.mojohaus.org/flatten-maven-plugin/flatten-mojo.html#flattenMode) of the plugin (issue https://github.com/mojohaus/flatten-maven-plugin/issues/84), but can be found in the [FlattenMode source code](https://github.com/mojohaus/flatten-maven-plugin/blob/flatten-maven-plugin-1.1.0/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java#L77-L80)