### PR TITLE
Maven does not provide mailing lists

### DIFF
--- a/content/markdown/what-is-maven.md
+++ b/content/markdown/what-is-maven.md
@@ -50,7 +50,6 @@ For example, Maven can provide:
 
 -   Change log document created directly from source control
 -   Cross referenced sources
--   Mailing lists
 -   Dependency list
 -   Unit test reports including coverage
 


### PR DESCRIPTION
@hboutemy Rather it can list the location of existing mailing lists, but it in no way creates or manages them. This is different than Cross referenced sources or change log documents, which it actually does create.