### PR TITLE
Fix typo in relocation mini-guide

### DIFF
--- a/content/apt/guides/mini/guide-relocation.apt
+++ b/content/apt/guides/mini/guide-relocation.apt
@@ -140,7 +140,7 @@ Guide to relocation
  files. First you should publish a pom with the new groupId <<<org.bar>>>.
  
  Because data in the repository is not supposed to change, Maven 2 doesn't
- download pom files that it has already downloaded. Therefor you will also need
+ download pom files that it has already downloaded. Therefore you will also need
  to publish a pom file with the old groupId <<<bar>>> for the new version. This
  should be a minimal relocation pom (as described in step 4 above), but for the
  new version of <<<foo>>>.


### PR DESCRIPTION
Hi,

Trying to relocate a repository, so am reading this page in Maven site, and found a typo.

Thanks for the documentation!

Bruno