### PR TITLE
[MNGSITE-371] Clarify that the issue number is an example

### DIFF
--- a/content/apt/guides/development/guide-maven-development.apt
+++ b/content/apt/guides/development/guide-maven-development.apt
@@ -72,7 +72,7 @@ Developing Maven
 
  * If this was a new piece of work without a JIRA issue, create a JIRA issue for it now.
 
- * Name the branch <<<MNG-<issue number>>>>.
+ * Name the branch after the issue number; the branch name would start with <<<\<jira-project-id>-<ticket-id\>>>>.
 
  * Push your branch with the commit(s) to your fork.
  


### PR DESCRIPTION
The current text could be interpreted in such a way that the branch should always start with `MNG-`. This is - of course - not the case. The new text is a bit more clear about that.