### PR TITLE
Adding extension to support packaging type maven-archetype in creating archetypes guide

### DIFF
--- a/content/apt/guides/mini/guide-creating-archetypes.apt
+++ b/content/apt/guides/mini/guide-creating-archetypes.apt
@@ -65,6 +65,15 @@ Guide to Creating Archetypes
   <artifactId>my-archetype-id</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+       </extension>
+     </extensions>
+   </build>
 </project>
 
 +----+


### PR DESCRIPTION
Using the pom in creating archetype guide results in the following error:
```
[ERROR]     Unknown packaging: maven-archetype @ line 9, column 16
```
I was able to resolve this by adding `archetype-packaging` extension.

Suggesting this change to the page to supply users with a working version of the example archetype pom.

Please correct me if there is a different way to handle this error, I found no other way.