### PR TITLE
[MNG-6432] Add warning about whitespace in mirrorOf

### DIFF
--- a/content/apt/guides/mini/guide-mirror-settings.apt
+++ b/content/apt/guides/mini/guide-mirror-settings.apt
@@ -122,6 +122,10 @@ Advanced Mirror Specification
 
  []
 
+  Be careful to not include extra whitespace around identifiers or wildcards in comma separated lists. For example,
+  a mirror with <<<<mirrorOf>>>> set to <<<!repo1, *>>> will not mirror anything while <<<!repo1,*>>> will mirror
+  everything but <<<repo1>>>.
+
   The position of wildcards within a comma separated list of repository identifiers is not important as the wildcards
   defer to further processing and explicit includes or excludes stop the processing, overruling any wildcard match.
 


### PR DESCRIPTION
Add a warning in Guide to Mirror Settings about extra whitespace in comma separated list value for mirrorOf.

I use this to block unintended downloads from central but made a mistake by using a space after the comma. As the mirror no longer matched central maven continued to use central while I thought I had disabled it.

Ideally, I would want Maven to detect and treat my mistake as an error but until we find a way to do that, I propose adding this warning to the documentation.

https://issues.apache.org/jira/browse/MNG-6432