### PR TITLE
Add MyGet to list Maven repository managers

### DIFF
--- a/content/markdown/repository-management.md
+++ b/content/markdown/repository-management.md
@@ -42,6 +42,7 @@ and the features provided by these products.
 * <a href="https://www.cloudsmith.io" target="_blank" rel="nofollow">Cloudsmith Package</a> (commercial)
 * <a href="https://www.jfrog.com/open-source" target="_blank" rel="nofollow">JFrog Artifactory Open Source</a> (open source)
 * <a href="https://www.jfrog.com/artifactory/" target="_blank" rel="nofollow">JFrog Artifactory Pro</a> (commercial)
+* <a href="https://www.myget.org" target="_blank" rel="nofollow">MyGet</a> (commercial)
 * <a href="https://www.sonatype.org/nexus/go/" target="_blank" rel="nofollow">Sonatype Nexus OSS</a> (open source)
 * <a href="https://links.sonatype.com/products/nexus/pro/home" target="_blank" rel="nofollow">Sonatype Nexus Pro</a> (commercial)
 * <a href="https://packagecloud.io" target="_blank" rel="nofollow">packagecloud.io</a> (commercial)


### PR DESCRIPTION
Hi team!
Appreciate your best practices article here - helpful high-level introduction article to provide context!
Proposing to include https://www.myget.org to the list of repository managers that support Maven in the list at the bottom of the article, for the sake of completeness/accuracy!