### PR TITLE
[MNG-4660] Improve documentation

### DIFF
--- a/content/apt/guides/mini/guide-multiple-modules.apt
+++ b/content/apt/guides/mini/guide-multiple-modules.apt
@@ -65,7 +65,7 @@ Guide to Working with Multiple Modules
 
   The following command line switches are available:
 
-    * <<<--resume-from>>> - resumes a reactor the specified project (e.g. when it fails in the middle)
+    * <<<--resume-from>>> - resumes a reactor from the specified project (e.g. when it fails in the middle)
 
     * <<<--also-make>>> - build the specified projects, and any of their dependencies in the reactor
 


### PR DESCRIPTION
While working on [MNG-4660](https://issues.apache.org/jira/browse/MNG-4660), I noticed that the wording in the "Guide to Working with Multiple Modules" was a bit unclear. Here's a suggestion how to fix that.