### PR TITLE
MNGSITE-399 - Fix the `banned dependencies rule` link at `Optional Dependencies and Dependency Exclusions` 

### DIFF
--- a/content/apt/guides/introduction/introduction-to-optional-and-excludes-dependencies.apt
+++ b/content/apt/guides/introduction/introduction-to-optional-and-excludes-dependencies.apt
@@ -314,7 +314,7 @@ Project-A
   
   If you truly want to ensure that a particular dependency appears nowhere in
   your classpath, regardless of path, the 
-  [banned dependencies rule](https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html)
+  {{{https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html}banned dependencies rule}}
   can be configured to fail the build if a problematic dependency is found.
   When the build fails, you'll need to add specific exclusions on each path
   the enforcer finds. 


### PR DESCRIPTION
Currently the link is constructed this way
```
[banned dependencies rule](https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html)
```
But even though that's valid Markdown syntax, the file is an APT (Almost Plain Text) instead of MD.

 

The correct syntax should be
```
{{{https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html}banned dependencies rule}}
```