### PR TITLE
Change 'plugins' to 'artifacts' in pom.apt

### DIFF
--- a/content/apt/pom.apt
+++ b/content/apt/pom.apt
@@ -1891,7 +1891,7 @@ scm:cvs:pserver:127.0.0.1:/cvs/root:my-project
 * {Plugin Repositories}
 
   Repositories are home to two major types of artifacts. The first are artifacts that are used as
-  dependencies of other artifacts. These are the majority of plugins that reside within central.
+  dependencies of other artifacts. These are the majority of artifacts that reside within central.
   The other type of artifact is plugins. Maven plugins are themselves a special type of artifact.
   Because of this, plugin repositories may be separated from other repositories (although, I have
   yet to hear a convincing argument for doing so). In any case, the structure of the <<<pluginRepositories>>>


### PR DESCRIPTION
Change the word "plugins" to "artifacts" when referring to the majority of artifacts in the central repository.