### PR TITLE
Add 'Customise the Maven Release process' blog

### DIFF
--- a/content/xdoc/articles.xml
+++ b/content/xdoc/articles.xml
@@ -91,6 +91,12 @@ under the License.
             <th>Published</th>
           </tr>
           <tr>
+            <td><a href="https://maarten.mulders.it/2020/01/customise-the-maven-release-process/">Customise the Maven Release process</a></td>
+            <td></td>
+            <td>Maarten Mulders</td>
+            <td>January 2020</td>
+          </tr>
+          <tr>
             <td><a href="http://www.sonatype.com/people/2009/08/create-a-customized-build-process-in-maven/">Create a Customized Build Process in Maven</a></td>
             <td></td>
             <td>John Casey</td>


### PR DESCRIPTION
Add a reference to my own blog post 'Customise the Maven Release process'. The reason I'm creating a merge request is two-fold:

1. I'm not sure if this place on the site is the right place for this kind of content.
1. I'm also the author of the blog post so I'd appreciate if somebody else could confirm it's a useful resource to list on the Maven website.