### PR TITLE
Fix Create the archetype descriptor example

### DIFF
--- a/content/apt/guides/mini/guide-creating-archetypes.apt
+++ b/content/apt/guides/mini/guide-creating-archetypes.apt
@@ -93,9 +93,9 @@ Guide to Creating Archetypes
 +----+
 
 <archetype-descriptor
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0
+        xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0
 	https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd"
-        xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
+        xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         name="quickstart">
     <fileSets>


### PR DESCRIPTION
Hello :)

The the `targetNamespace` of the [Archetype Descriptor XML Schema Definition](https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd) is 

> http**s**://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0

The namespace used in this file is
> http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0

In the example, the `s` was missing from `http`, this PR fix that.

Thank you very much for all the work down in this project,