### PR TITLE
document all allowed elements inside profiles

### DIFF
--- a/content/apt/guides/introduction/introduction-to-profiles.apt
+++ b/content/apt/guides/introduction/introduction-to-profiles.apt
@@ -346,8 +346,8 @@ mvn groupId:artifactId:goal -P !profile-1,!profile-2
   it's reasonable to say you can add more information to them without the risk
   of that information being unavailable to other users.
 
-  Profiles specified in the POM can modify the following POM elements as outlined
-  in the {{{/ref/current/maven-model/maven.html}maven model}}:
+  Profiles specified in the POM can modify the
+  {{{/ref/current/maven-model/maven.html}the following POM elements}}:
 
   * <<<\<repositories\>>>>
 

--- a/content/apt/guides/introduction/introduction-to-profiles.apt
+++ b/content/apt/guides/introduction/introduction-to-profiles.apt
@@ -346,7 +346,8 @@ mvn groupId:artifactId:goal -P !profile-1,!profile-2
   it's reasonable to say you can add more information to them without the risk
   of that information being unavailable to other users.
 
-  Profiles specified in the POM can modify the following POM elements:
+  Profiles specified in the POM can modify the following POM elements as outlined
+  in the {{{/ref/current/maven-model/maven.html}maven model}}:
 
   * <<<\<repositories\>>>>
 
@@ -360,6 +361,8 @@ mvn groupId:artifactId:goal -P !profile-1,!profile-2
     scenes)
 
   * <<<\<modules\>>>>
+
+  * <<<\<reports\>>>>
 
   * <<<\<reporting\>>>>
 
@@ -375,7 +378,15 @@ mvn groupId:artifactId:goal -P !profile-1,!profile-2
 
     * <<<\<testResources\>>>>
 
+    * <<<\<directory\>>>>
+
     * <<<\<finalName\>>>>
+
+    * <<<\<filters\>>>>
+
+    * <<<\<pluginManagement\>>>>
+
+    * <<<\<plugins\>>>>
 
   []
 

--- a/content/apt/guides/introduction/introduction-to-profiles.apt
+++ b/content/apt/guides/introduction/introduction-to-profiles.apt
@@ -346,7 +346,7 @@ mvn groupId:artifactId:goal -P !profile-1,!profile-2
   it's reasonable to say you can add more information to them without the risk
   of that information being unavailable to other users.
 
-  Profiles specified in the POM can modify the
+  Profiles specified in the POM can modify
   {{{/ref/current/maven-model/maven.html}the following POM elements}}:
 
   * <<<\<repositories\>>>>


### PR DESCRIPTION
Previously the list was incomplete but did not infer the list was partial, e.g.
by using the word "some". If a user comes across the introductory guide first,
then it is easy to miss the complete model documentation and not find the
complete set of valid elements.

As discussed, the following have been updated:
- the remaining few elements have been added to complete the list.
- a link to the full model documentation is now provided.