### PR TITLE
Add 'What's New in Maven 4' blog

### DIFF
--- a/content/xdoc/articles.xml
+++ b/content/xdoc/articles.xml
@@ -97,6 +97,12 @@ under the License.
             <td>March 2021</td>
           </tr>
           <tr>
+              <td><a href="https://maarten.mulders.it/2020/11/whats-new-in-maven-4/">What's New in Maven 4</a></td>
+              <td></td>
+              <td>Maarten Mulders</td>
+              <td>November 2020</td>
+          </tr>
+          <tr>
             <td><a href="https://maarten.mulders.it/2020/01/customise-the-maven-release-process/">Customise the Maven Release process</a></td>
             <td></td>
             <td>Maarten Mulders</td>


### PR DESCRIPTION
Add a reference to the blog post 'What's New in Maven 4' by @MartinKanters and myself. The reason I'm creating a merge request is two-fold:

1. I'm not sure if this place on the site is the right place for this kind of content.
1. I'm also the co-author of the blog post so I'd appreciate if somebody else could confirm it's a useful resource to list on the Maven website.
