### PR TITLE
The maven-ear-plugin supports reproducible builds since 3.1.0

### DIFF
--- a/content/apt/guides/mini/guide-reproducible-builds.apt
+++ b/content/apt/guides/mini/guide-reproducible-builds.apt
@@ -141,6 +141,8 @@ Configuring for Reproducible Builds
 *----------------------------------------------------------------------------+-------+--------------+
 | {{{/plugins/maven-war-plugin/}maven-war-plugin}}                           | 3.3.1 |
 *----------------------------------------------------------------------------+-------+--------------+
+| {{{/plugins/maven-ear-plugin/}maven-ear-plugin}}                           | 3.1.0 |
+*----------------------------------------------------------------------------+-------+--------------+
 | {{{https://codehaus-plexus.github.io/plexus-containers/plexus-component-metadata/}plexus-component-metadata}} | 2.1.0 |
 *----------------------------------------------------------------------------+-------+--------------+
 | {{{https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin}bnd-maven-plugin}} |   | see {{{https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin#reproducible-builds}configuration instructions}}


### PR DESCRIPTION
Since [MEAR-280](https://issues.apache.org/jira/browse/MEAR-280) and [MEAR-283](https://issues.apache.org/jira/browse/MEAR-283), the maven-ear-plugin supports reproducible builds. So, the minimum version is 3.1.0.