### PR TITLE
Use an SPDX identifier in example, as recommended

### DIFF
--- a/content/apt/pom.apt
+++ b/content/apt/pom.apt
@@ -1472,10 +1472,10 @@ Display parameters as parsed by Maven (in canonical form) and comparison result:
 +-------------------------+
 <licenses>
   <license>
-    <name>Apache License, Version 2.0</name>
+    <name>Apache-2.0</name>
     <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     <distribution>repo</distribution>
-    <comments>A business-friendly OSS license</comments>
+    <comments>Apache License, Version 2.0 — a business-friendly open source license</comments>
   </license>
 </licenses>
 +-------------------------+


### PR DESCRIPTION
The text says:

> Using an SPDX identifier as the license name is recommended.

But then doesn't use one in the example. I found this confusing.