### PR TITLE
Fix encoding in the example of toolchains.xml

### DIFF
--- a/content/apt/guides/mini/guide-using-toolchains.apt
+++ b/content/apt/guides/mini/guide-using-toolchains.apt
@@ -139,7 +139,7 @@ Guide to Using Toolchains
 
 
 +-----+
-<?xml version="1.0" encoding="UTF8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <toolchains>
   <!-- JDK toolchains -->
   <toolchain>


### PR DESCRIPTION
UTF8 is an illegal name of the UTF-8 encoding. The dash is mandatory.