### PR TITLE
Add Gradle Enterprise extension

### DIFF
--- a/content/markdown/extensions/index.md
+++ b/content/markdown/extensions/index.md
@@ -36,10 +36,11 @@ under the License.
 
 A number of other projects provide their own Maven extensions. This includes:
 
-| Extension      | Maintainer                                                     | Description 
-|----------------|----------------------------------------------------------------|-----------
-| notifier       | [Jean-Christophe Gay](https://github.com/jcgay/maven-notifier) | A status notification will be send at the end of a Maven build.
-| polyglot       | [Takari](https://github.com/takari/polyglot-maven)             | Polyglot for Maven is a set of extensions that allows the POM model to be written in dialects other than XML. 
-| profiler       | [Jean-Christophe Gay](https://github.com/jcgay/maven-profiler) | A time execution recorder for Maven which log time taken by each mojo in your build lifecycle.
-|                | [Takari](https://github.com/takari/maven-profiler)             | The Tesla profiler is a simple EventSpy implementation that gathers timing information.
-| smart-builder  | [Takari](https://github.com/takari/takari-smart-builder)       | The Takari Smart Builder is a replacement scheduling projects builds in a Maven multi-module build.
+| Extension         | Maintainer                                                         | Description 
+|-------------------|--------------------------------------------------------------------|-----------
+| Gradle Enterprise | [Gradle Inc.](https://docs.gradle.com/enterprise/maven-extension/) | Captures Maven build insights that can be viewed for free on [scans.gradle.com](https://scans.gradle.com/). Provides local and remote build caching and distributed test execution for Maven builds connected to a Gradle Enterprise installation.
+| notifier          | [Jean-Christophe Gay](https://github.com/jcgay/maven-notifier)     | A status notification will be send at the end of a Maven build.
+| polyglot          | [Takari](https://github.com/takari/polyglot-maven)                 | Polyglot for Maven is a set of extensions that allows the POM model to be written in dialects other than XML. 
+| profiler          | [Jean-Christophe Gay](https://github.com/jcgay/maven-profiler)     | A time execution recorder for Maven which log time taken by each mojo in your build lifecycle.
+|                   | [Takari](https://github.com/takari/maven-profiler)                 | The Tesla profiler is a simple EventSpy implementation that gathers timing information.
+| smart-builder     | [Takari](https://github.com/takari/takari-smart-builder)           | The Takari Smart Builder is a replacement scheduling projects builds in a Maven multi-module build.

--- a/content/markdown/extensions/index.md
+++ b/content/markdown/extensions/index.md
@@ -36,11 +36,18 @@ under the License.
 
 A number of other projects provide their own Maven extensions. This includes:
 
-| Extension         | Maintainer                                                         | Description 
+### Open Source
+
+| Extension      | Maintainer                                                     | Description 
+|----------------|----------------------------------------------------------------|-----------
+| notifier       | [Jean-Christophe Gay](https://github.com/jcgay/maven-notifier) | A status notification will be send at the end of a Maven build.
+| polyglot       | [Takari](https://github.com/takari/polyglot-maven)             | Polyglot for Maven is a set of extensions that allows the POM model to be written in dialects other than XML. 
+| profiler       | [Jean-Christophe Gay](https://github.com/jcgay/maven-profiler) | A time execution recorder for Maven which log time taken by each mojo in your build lifecycle.
+|                | [Takari](https://github.com/takari/maven-profiler)             | The Tesla profiler is a simple EventSpy implementation that gathers timing information.
+| smart-builder  | [Takari](https://github.com/takari/takari-smart-builder)       | The Takari Smart Builder is a replacement scheduling projects builds in a Maven multi-module build.
+
+### Commercial
+
+| Extension         | Maintainer                                                         | Description
 |-------------------|--------------------------------------------------------------------|-----------
 | Gradle Enterprise | [Gradle Inc.](https://docs.gradle.com/enterprise/maven-extension/) | Captures Maven build insights that can be viewed for free on [scans.gradle.com](https://scans.gradle.com/). Provides local and remote build caching and distributed test execution for Maven builds connected to a Gradle Enterprise installation.
-| notifier          | [Jean-Christophe Gay](https://github.com/jcgay/maven-notifier)     | A status notification will be send at the end of a Maven build.
-| polyglot          | [Takari](https://github.com/takari/polyglot-maven)                 | Polyglot for Maven is a set of extensions that allows the POM model to be written in dialects other than XML. 
-| profiler          | [Jean-Christophe Gay](https://github.com/jcgay/maven-profiler)     | A time execution recorder for Maven which log time taken by each mojo in your build lifecycle.
-|                   | [Takari](https://github.com/takari/maven-profiler)                 | The Tesla profiler is a simple EventSpy implementation that gathers timing information.
-| smart-builder     | [Takari](https://github.com/takari/takari-smart-builder)           | The Takari Smart Builder is a replacement scheduling projects builds in a Maven multi-module build.


### PR DESCRIPTION
This PR adds the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/) to the list of "Outside The Maven Land" extensions. I interpreted the existing data as being sorted alphabetically and hence added it at the top of the list. Please let me know if you want a different order or any other changes.

---

![image](https://user-images.githubusercontent.com/214207/132862720-3f9f3d3f-9530-4e1d-bfef-b3655f2c94da.png)
