### PR TITLE
guide-site.apt: fix typo in mvn command

### DIFF
--- a/content/apt/guides/mini/guide-site.apt
+++ b/content/apt/guides/mini/guide-site.apt
@@ -157,7 +157,7 @@ mvn site-deploy
 
   Deploying the site is done in 2 steps:
   
-  [[1]] staging the content by using the <<<site>>> phase of the site lifecycle followed by <<<site:stage>>>: <<<mvn site site-stage>>>
+  [[1]] staging the content by using the <<<site>>> phase of the site lifecycle followed by <<<site:stage>>>: <<<mvn site site:stage>>>
 
   [[2]] publishing the staged site to the SCM: <<<mvn scm-publish:publish-scm>>>
 


### PR DESCRIPTION
Just a one-character fix, but it was enough to confuse me for a bit. :sweat_smile:

Since there's already a `site-deploy` phase in the built-in `site` lifecycle, I thought perhaps there was also a `site-stage` phase, and went looking around for it to understand why it wasn't mentioned in the list of phases of the site lifecycle (and of course I didn't find it.)