### PR TITLE
[MNGSITE-461] Remove IRC contact channel from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Additional Resources
 + [General GitHub documentation](https://help.github.com/)
 + [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
 + [Apache Maven Twitter Account](https://twitter.com/ASFMavenProject)
-+ "#Maven" IRC channel on freenode.org
++ [Slack channel in ASF Workspace](https://infra.apache.org/slack.html)
 
 [jira]: https://issues.apache.org/jira/projects/MNGSITE/
 [license]: https://www.apache.org/licenses/LICENSE-2.0

--- a/content/fml/about.fml
+++ b/content/fml/about.fml
@@ -95,14 +95,7 @@
           Help for Maven can be obtained by subscribing and posting to the
           <a href="https://maven.apache.org/mailing-lists.html">Maven Users List</a>.
         </p>
-        <p>
-          You can also join us on IRC (Internet Relay Chat) at <code>irc.freenode.net</code>
-          on <code>#maven</code>. 
-          over <a href="irc://irc.freenode.net/#maven">IRC</a>
-          for those behind firewalls (enter <code>#maven</code> in the <i>Channel</i> box).
-        </p>
       </answer>
     </faq>
   </part>
 </faqs>
-

--- a/content/markdown/community.md
+++ b/content/markdown/community.md
@@ -85,8 +85,8 @@ Maven has a number of [Mailing Lists](./mailing-lists.html), and the Maven
 User List is specifically dedicated to answering questions about all
 Maven things.
 
-#### IRC (Internet Relay Chat)
+#### Slack
 
-Log into the `#maven` IRC channel on `irc.freenode.net` with your
-favorite IRC client or [with web IRC chat](https://webchat.freenode.net/).
-
+For people actively contributing to Maven, especially committers, there
+is [the ASF Slack workspace](https://infra.apache.org) available to discuss
+issues, solve problems and build community in real-time.

--- a/content/xdoc/index.xml.vm
+++ b/content/xdoc/index.xml.vm
@@ -24,7 +24,7 @@ under the License.
     <title>Welcome to Apache Maven</title>
     <author email="brett@apache.org">Brett Porter</author>
     <author email="jason@takari.io">Jason van Zyl</author>
-    <author email="olamy@apache.org">Olivier Lamy</author>    
+    <author email="olamy@apache.org">Olivier Lamy</author>
   </properties>
   <body>
 
@@ -115,7 +115,7 @@ under the License.
         will answer your questions there, and the answer will be archived for others in the future.
       </p>
       <p>
-        You can also reach the Maven developers on <a href="community.html">IRC</a>.
+        You can also reach the Maven developers on <a href="community.html">Slack</a>.
       </p>
 
       <h3>Apache Software Foundation</h3>


### PR DESCRIPTION
FreeNode's #maven is not active anymore. Replaced with some Slack information is more pointing to the right communication channel.