### PR TITLE
Version requirement for versions before next major release

### DIFF
--- a/content/apt/pom.apt
+++ b/content/apt/pom.apt
@@ -541,6 +541,10 @@ mvn install:install-file -Dfile=non-maven-proj.jar -DgroupId=some.group -Dartifa
 
   Note: Contrary to what was stated in some design documents, for version order, snapshots are not treated differently than releases or any other qualifier.
 
+  Note: As <<<2.0-rc1>>> \< <<<2.0>>>, the version requirement <<<[1.0,2.0)>>> excludes <<<2.0>>> but includes version <<<2.0-rc1>>>, which is contrary to
+  what most people expect. In addition, Gradle interprets it differently, resulting in different dependency trees for the same POM.
+  If the intention is to restrict it to <1.*> versions, the better version requirement is <<<[1,1.999999)>>>.
+
 *** {Version Order Testing}:
 
     The maven distribution includes a tool to check version order. It was used to produce the examples in the previous paragraphs. Feel free to run it yourself when in doubt. You can run it like this:


### PR DESCRIPTION
In a POM, one would often like to restrict a dependency to a version before the next major release (incl. pre-releases). This does not work as most people would expect. So the proposed paragraph explains how to do it.