### PR TITLE
typo in "direct plugin goal invocation" example

### DIFF
--- a/content/apt/guides/mini/guide-configuring-plugins.apt
+++ b/content/apt/guides/mini/guide-configuring-plugins.apt
@@ -561,7 +561,7 @@ public class MyBoundQueryMojo
   command-line, you can execute:
 
 +----+
-mvn myqyeryplugin:queryMojo@execution1
+mvn myquery:query@execution1
 +----+
 
 ** {Using the <<<\<dependencies\>>>> Tag}


### PR DESCRIPTION
The example given for invoking a direct plugin goal execution has a typo. I think this fix has the correct syntax.