### PR TITLE
Removing line about contacting Sonatype to set up a new mirror

### DIFF
--- a/content/apt/guides/mini/guide-mirror-settings.apt
+++ b/content/apt/guides/mini/guide-mirror-settings.apt
@@ -176,5 +176,3 @@ Creating Your Own Mirror
   To save us bandwidth and you time, mirroring the entire central repository is not allowed. 
   (Doing so will get you automatically banned.) Instead, we suggest you setup a
   {{{../../repository-management.html}repository manager}} as a proxy.
-
-  If you really want to become an official mirror, contact Sonatype at {{{https://issues.sonatype.org/browse/MVNCENTRAL}MVNCENTRAL}} with your location and we'll work to get you setup.


### PR DESCRIPTION
I'm also planning to update https://repo.maven.apache.org/maven2/.meta/repository-metadata.xml with a list of current mirrors (outdated mirrors have been commented out and Google mirrors added).