### PR TITLE
Mngsite 414 clean up https /maven.apache.org/configure.html

### DIFF
--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -19,8 +19,9 @@ under the License.
 -->
 
 Apache Maven ships with two launcher commands in the `${MAVEN_HOME}/bin` folder,
-which based on several environment variables, project files and system files, constructs
-and runs the appropriate `java ...` command line.  
+which - based on several environment variables, project files and system files as described below
+- constructs and runs the appropriate `java ...` command line which then invokes the Java Virtual Machine (JVM) 
+that actually runs Maven.
 
 * `mvn` - normal way to run from the command line.
 * `mvnDebug` - launches `mvn` in debug mode, waiting for a Java debugger to attach to port `$MAVEN_DEBUG_ADDRESS` (default 8000).
@@ -35,13 +36,12 @@ For Windows the syntax is slightly different, for `$A` use `%A%`.
 ### `$MAVEN_OPTS` - `%MAVEN_OPTS%`
 
 The contents of this variable is placed in the `java` command _before_ the class name, and 
-can therefore be used to provide additional arguments to the JVM. 
+can therefore be used to provide additional arguments to the Java Virtual Machine (JVM) without
+having to specify them on the command line every time.
 
-FIXME:  Better example of what to use.
+Examples include garbage collector and memory configuration, but _not_ options to Maven itself
 
-This variable contains parameters used to start up the JVM running Maven and
-can be used to supply additional options to it. E.g. JVM memory
-settings could be defined with the value `-Xms256m -Xmx512m`.
+Use `java --help` and `java -X` to see what is possible in this particular JVM.
 
 <!--
 ### `$MAVEN_ARGS`
@@ -55,10 +55,8 @@ CLI arguments. E.g., options and goals could be defined with the value
 
 If set, this is considered the base directory of the Maven project.  If not set, 
 the launcher scripts search for a `.mvn` folder towards the root of the drive, and if
-found consider that the base directory.  
+found consider that the base directory.
 
-FIXME:
-The `-f` command line argument overrides this.
 
 ### `$MAVEN_SKIP_RC` - `%MAVEN_SKIP_RC%`
 
@@ -77,22 +75,16 @@ They are put after `$MAVEN_OPTS` and before the `-classpath` argument.
 
 ## Files
 
-Files underneath `$MAVEN_BASEDIR` are part of your project and may be checked 
+Files in `$MAVEN_BASEDIR` and below are part of your project and may be checked 
 into source control.
-
-FIXME:  Get all %'s right for Windows paths.
 
 ### `$USER/.m2/settings.xml` - `%USER_HOME%\.m2\settings.xml`
 
 This contains the user-specific Maven setup used across projects.  
-Often this is used to tell Maven to
-use an internal repository instead of Maven Central if behind a firewall, 
-various profiles, 
-and passwords.
+Often this is used to tell Maven to use an internal repository instead of Maven Central if behind a firewall, 
+various profiles, and passwords.
 
-### `$MAVEN_BASEDIR/.mvn/config`:
-
-FIXME: Is this a thing?
+<!-- 
 
 ### `$MAVEN_BASEDIR/.mvn/maven.config`:
 
@@ -104,6 +96,7 @@ For example things like `-T3 -U --fail-at-end`.
 So you only have to call Maven just by using `mvn clean package` 
 instead of `mvn -T3 -U --fail-at-end clean package`.
 
+-->
 
 ### `$MAVEN_BASEDIR/.mvn/jvm.config`:
 
@@ -113,13 +106,18 @@ additional arguments to the JVM before the class name on the constructed
 
         -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true
 
+Word of caution:  If you for any reason need to configure memory usage or the garbage collector - which should
+be considered a last resort - be absolutely certain that the configuration you use 
+applies to the version of the JVM you are using, and that you understand what you are doing.
+
 
 ### `$MAVEN_BASEDIR/.mvn/extensions.xml`
+
+FIXME:  WHERE IS THIS DONE?  IS THIS MAVEN 4 FUNCTIONALITY?
 
 If you for any reason needs additional artifacts put on the classpath used by Maven,
 simply list them here with their usual Maven coordinates.
 
-FIXME:  Where is this done?
 
 ```xml
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -138,13 +136,15 @@ Unix-like systems only:
 Configuration files executed by the Unix launcher scripts first thing, unless
 if the environment variable `$MAVEN_SKIP_RC` is set.
 
+Typically environment variables - including `$PATH` - are set here.
+
 ### `%USERPROFILE%\mavenrc_pre.bat` + `%USERPROFILE%\mavenrc_pre.cmd`
 
 Windows systems only:
-Configuration files executed by the Windows launcher scripts first thing, unless
-if the environment variable `%MAVEN_SKIP_RC%` is set.
+Configuration files executed by the Windows launcher scripts first thing _before_ launching the Maven JVM, 
+unless if the environment variable `%MAVEN_SKIP_RC%` is set.
 
-This is useful for providing secrets, like the password for a keystore:
+This can be used to provide secrets, like the password for a keystore:
 
 ```
 set MAVEN_OPTS=-Djavax.net.ssl.keyStore="<path to p12 file>" -Djavax.net.ssl.keyStoreType=pkcs12 -Djavax.net.ssl.keyStorePassword=<password>
@@ -153,7 +153,7 @@ set MAVEN_OPTS=-Djavax.net.ssl.keyStore="<path to p12 file>" -Djavax.net.ssl.key
 ### `%USERPROFILE%\mavenrc_post.bat` + `%USERPROFILE%\mavenrc_post.cmd`
 
 Windows systems only:
-Configuration files executed by the Windows launcher scripts after Maven itself exits, unless
+Configuration files executed by the Windows launcher scripts _after_ the Maven JVM itself exits, unless
 if the environment variable `%MAVEN_SKIP_RC%` is set.
 
 

--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -143,6 +143,12 @@ Windows systems only:
 Configuration files executed by the Windows launcher scripts first thing, unless
 if the environment variable `%MAVEN_SKIP_RC%` is set.
 
+This is useful for providing secrets, like the password for a keystore:
+
+```
+set MAVEN_OPTS=-Djavax.net.ssl.keyStore="<path to p12 file>" -Djavax.net.ssl.keyStoreType=pkcs12 -Djavax.net.ssl.keyStorePassword=<password>
+```
+
 ### `%USERPROFILE%\mavenrc_post.bat` + `%USERPROFILE%\mavenrc_post.cmd`
 
 Windows systems only:

--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -28,10 +28,11 @@ and runs the appropriate `java ...` command line.
 
 ## Environment variables
 
-In the following the Unix syntax for environment variables is used.  For `$A` the 
-Windows equivalent is `%A%`.
+In the following the Unix syntax for environment variables is used in the text.
 
-### `$MAVEN_OPTS`
+For Windows the syntax is slightly different, for `$A` use `%A%`.
+
+### `$MAVEN_OPTS` - `%MAVEN_OPTS%`
 
 The contents of this variable is placed in the `java` command _before_ the class name, and 
 can therefore be used to provide additional arguments to the JVM. 
@@ -50,7 +51,7 @@ CLI arguments. E.g., options and goals could be defined with the value
 `-B -V checkstyle:checkstyle`.
 -->
 
-### `$MAVEN_BASEDIR`
+### `$MAVEN_BASEDIR` - `%MAVEN_BASEDIR%`
 
 If set, this is considered the base directory of the Maven project.  If not set, 
 the launcher scripts search for a `.mvn` folder towards the root of the drive, and if
@@ -59,17 +60,17 @@ found consider that the base directory.
 FIXME:
 The `-f` command line argument overrides this.
 
-### `$MAVEN_SKIP_RC`
+### `$MAVEN_SKIP_RC` - `%MAVEN_SKIP_RC%`
 
 If set, tells the launcher scripts _not_ to read the various Maven configuration files.
 This is useful to get standard behaviour.
 
-### `$JAVA_HOME`
+### `$JAVA_HOME` - `%JAVA_HOME%`
 
 If set, the Java binary to be used must be found at `$JAVA_HOME/bin/java` or an error will
 be reported.  If not set, the Java binary is found in the `$PATH`.
 
-### `$MAVEN_DEBUG_OPTS`
+### `$MAVEN_DEBUG_OPTS` - `%MAVEN_DEBUG_OPTS%`
 
 Additional options for the JVM if needed.  
 They are put after `$MAVEN_OPTS` and before the `-classpath` argument.
@@ -81,7 +82,7 @@ into source control.
 
 FIXME:  Get all %'s right for Windows paths.
 
-### `$USER_HOME/.m2/settings.xml` - `%USER_HOME%\.m2\settings.xml`
+### `$USER/.m2/settings.xml` - `%USER_HOME%\.m2\settings.xml`
 
 This contains the user-specific Maven setup used across projects.  
 Often this is used to tell Maven to

--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -23,10 +23,13 @@ which based on several environment variables, project files and system files, co
 and runs the appropriate `java ...` command line.  
 
 * `mvn` - normal way to run from the command line.
-* `MvnDebug` - launches `mvn` in debug mode, waiting for a debugger to attach to port `$MAVEN_DEBUG_ADDRESS` (default 8000).
+* `mvnDebug` - launches `mvn` in debug mode, waiting for a Java debugger to attach to port `$MAVEN_DEBUG_ADDRESS` (default 8000).
+
 
 ## Environment variables
 
+In the following the Unix syntax for environment variables is used.  For `$A` the 
+Windows equivalent is `%A%`.
 
 ### `$MAVEN_OPTS`
 
@@ -47,7 +50,7 @@ CLI arguments. E.g., options and goals could be defined with the value
 `-B -V checkstyle:checkstyle`.
 -->
 
-### `$MAVEN_BASEDIR`:
+### `$MAVEN_BASEDIR`
 
 If set, this is considered the base directory of the Maven project.  If not set, 
 the launcher scripts search for a `.mvn` folder towards the root of the drive, and if
@@ -55,6 +58,21 @@ found consider that the base directory.
 
 FIXME:
 The `-f` command line argument overrides this.
+
+### `$MAVEN_SKIP_RC`
+
+If set, tells the launcher scripts _not_ to read the various Maven configuration files.
+This is useful to get standard behaviour.
+
+### `$JAVA_HOME`
+
+If set, the Java binary to be used must be found at `$JAVA_HOME/bin/java` or an error will
+be reported.  If not set, the Java binary is found in the `$PATH`.
+
+### `$MAVEN_DEBUG_OPTS`
+
+Additional options for the JVM if needed.  
+They are put after `$MAVEN_OPTS` and before the `-classpath` argument.
 
 ## Files
 
@@ -77,9 +95,9 @@ FIXME: Is this a thing?
 
 ### `$MAVEN_BASEDIR/.mvn/maven.config`:
 
-This file contains additional command line arguments added to every invocation of Maven.
+FIXME:  IS THIS STILL THE CASE? LAUNCHER SCRIPTS DOES NOT LOOK FOR IT?!?
 
-FIXME:  Something more useful?
+This file contains additional command line arguments added to every invocation of Maven.
 
 For example things like `-T3 -U --fail-at-end`. 
 So you only have to call Maven just by using `mvn clean package` 
@@ -95,10 +113,10 @@ additional arguments to the JVM before the class name on the constructed
         -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true
 
 
-### `$MAVEN_BASEDIR/.mvn/extensions.xml` file:
+### `$MAVEN_BASEDIR/.mvn/extensions.xml`
 
 If you for any reason needs additional artifacts put on the classpath used by Maven,
-simply list them here with their usual maven coordinates.
+simply list them here with their usual Maven coordinates.
 
 FIXME:  Where is this done?
 
@@ -112,6 +130,27 @@ FIXME:  Where is this done?
   </extension>
 </extensions>
 ```
+
+### `/usr/local/etc/mavenrc` + `/etc/mavenrc` + `$HOME/.mavenrc`
+
+Unix-like systems only: 
+Configuration files executed by the Unix launcher scripts first thing, unless
+if the environment variable `$MAVEN_SKIP_RC` is set.
+
+### `%USERPROFILE%\mavenrc_pre.bat` + `%USERPROFILE%\mavenrc_pre.cmd`
+
+Windows systems only:
+Configuration files executed by the Windows launcher scripts first thing, unless
+if the environment variable `%MAVEN_SKIP_RC%` is set.
+
+### `%USERPROFILE%\mavenrc_post.bat` + `%USERPROFILE%\mavenrc_post.cmd`
+
+Windows systems only:
+Configuration files executed by the Windows launcher scripts after Maven itself exits, unless
+if the environment variable `%MAVEN_SKIP_RC%` is set.
+
+
+---
 
 
 ## Other guides

--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -17,42 +17,90 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-The configuration for Apache Maven usage itself and projects built with resides 
-in a number of places: 
 
-## `MAVEN_OPTS` environment variable:
+Apache Maven ships with two launcher commands in the `${MAVEN_HOME}/bin` folder,
+which based on several environment variables, project files and system files, constructs
+and runs the appropriate `java ...` command line.  
+
+* `mvn` - normal way to run from the command line.
+* `MvnDebug` - launches `mvn` in debug mode, waiting for a debugger to attach to port `$MAVEN_DEBUG_ADDRESS` (default 8000).
+
+## Environment variables
+
+
+### `$MAVEN_OPTS`
+
+The contents of this variable is placed in the `java` command _before_ the class name, and 
+can therefore be used to provide additional arguments to the JVM. 
+
+FIXME:  Better example of what to use.
 
 This variable contains parameters used to start up the JVM running Maven and
 can be used to supply additional options to it. E.g. JVM memory
 settings could be defined with the value `-Xms256m -Xmx512m`.
 
-## `MAVEN_ARGS` environment variable:
+<!--
+### `$MAVEN_ARGS`
 
 Starting with Maven 4, this variable contains arguments passed to Maven before
 CLI arguments. E.g., options and goals could be defined with the value
 `-B -V checkstyle:checkstyle`.
+-->
 
-## `settings.xml` file:
+### `$MAVEN_BASEDIR`:
 
-Located in USER_HOME/.m2 the settings files is designed to contain any
-configuration for Maven usage across projects.
+If set, this is considered the base directory of the Maven project.  If not set, 
+the launcher scripts search for a `.mvn` folder towards the root of the drive, and if
+found consider that the base directory.  
 
-## `.mvn` directory:
+FIXME:
+The `-f` command line argument overrides this.
 
-Located within the project's top level directory, the files `maven.config`, `jvm.config`, and `extensions.xml`
-contain project specific configuration for running Maven.
+## Files
 
-This directory is part of the project and may be checked in into your version control.
+Files underneath `$MAVEN_BASEDIR` are part of your project and may be checked 
+into source control.
 
-### `.mvn/extensions.xml` file:
+FIXME:  Get all %'s right for Windows paths.
 
-The old way (up to Maven 3.2.5) was to create a jar (must be shaded if you have other dependencies) which contains the extension and put 
-it manually into the `${MAVEN_HOME}/lib/ext` directory. This means you had to change the Maven installation. The consequence was that everyone
-who likes to use this needed to change it’s installation and makes the on-boarding for a developer much more inconvenient. The other 
-option was to give the path to the jar on command line via `mvn -Dmaven.ext.class.path=extension.jar`. This has the drawback giving those 
-options to your Maven build every time you are calling Maven. Not very convenient as well.
+### `$USER_HOME/.m2/settings.xml` - `%USER_HOME%\.m2\settings.xml`
 
-From now on this can be done much more simpler and in a more Maven like way. So you can define an `${maven.projectBasedir}/.mvn/extensions.xml` file which looks like the following:
+This contains the user-specific Maven setup used across projects.  
+Often this is used to tell Maven to
+use an internal repository instead of Maven Central if behind a firewall, 
+various profiles, 
+and passwords.
+
+### `$MAVEN_BASEDIR/.mvn/config`:
+
+FIXME: Is this a thing?
+
+### `$MAVEN_BASEDIR/.mvn/maven.config`:
+
+This file contains additional command line arguments added to every invocation of Maven.
+
+FIXME:  Something more useful?
+
+For example things like `-T3 -U --fail-at-end`. 
+So you only have to call Maven just by using `mvn clean package` 
+instead of `mvn -T3 -U --fail-at-end clean package`.
+
+
+### `$MAVEN_BASEDIR/.mvn/jvm.config`:
+
+Allows a persistable alternative to `$MAVEN_OPTS` for providing 
+additional arguments to the JVM before the class name on the constructed 
+`java ...` command line.  Sample contents: 
+
+        -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true
+
+
+### `$MAVEN_BASEDIR/.mvn/extensions.xml` file:
+
+If you for any reason needs additional artifacts put on the classpath used by Maven,
+simply list them here with their usual maven coordinates.
+
+FIXME:  Where is this done?
 
 ```xml
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -65,26 +113,6 @@ From now on this can be done much more simpler and in a more Maven like way. So 
 </extensions>
 ```
 
-Now you can simply use an extension by defining the usual maven coordinates groupId, artifactId, version as any other artifact. Furthermore all transitive dependencies of those extensions will automatically being downloaded from your repository. So no need to create a shaded artifact anymore.
-
-### `.mvn/maven.config` file:
-
-It’s really hard to define a general set of options for calling the maven command line. Starting with Maven 3.3.1+, this can be solved by 
-putting this 
-options to a script but this can now simple being done by defining `${maven.projectBasedir}/.mvn/maven.config` file which contains the 
-configuration options for the `mvn` command line. 
-
-For example things like `-T3 -U --fail-at-end`. So you only have to call Maven just by using `mvn 
-clean package` instead of `mvn -T3 -U --fail-at-end clean package` and not to miss the `-T3 -U --fail-at-end` options on every call. The 
-`${maven.projectBasedir}/.mvn/maven.config` is located in the `${maven.projectBasedir}/.mvn/` directory; also works if in the root of a multi module build.
-
-### `.mvn/jvm.config` file:
-
-Starting with Maven 3.3.1+ you can define JVM configuration via `${maven.projectBasedir}/.mvn/jvm.config` file which means you can define the options for your build on a per project base. This file will become part of your project and will be checked in along with your project. So no need anymore for `MAVEN_OPTS`, `.mavenrc` files. So for example if you put the following JVM options into the `${maven.projectBasedir}/.mvn/jvm.config` file
-
-        -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true
-
-You don't need to use these options in `MAVEN_OPTS` or switch between different configurations.
 
 ## Other guides
 


### PR DESCRIPTION
I have had a look at the current launcher scripts (mvn/mvnDebug) and updated configure.md accordingly.

Notably, Maven 4 information has been commented out for now.