### PR TITLE
[MNGSITE-491] Update commit policy related document

### DIFF
--- a/content/apt/developers/conventions/git.apt
+++ b/content/apt/developers/conventions/git.apt
@@ -64,8 +64,12 @@ Maven Git Convention
 ** For committers
 
   Committers may, of course, commit directly to the ASF repositories.
-  For complex changes, you may find it valuable to make a pull request
-  at github to make it easier to collaborate with others.
+  For complex changes or changes against stable branches it is required
+  to make a pull request at github to make it easier to collaborate with
+  others. For simple/trivial changes, it is okay for a committer to push
+  directly to repository and not create PR. Whether pull requests are created
+  from branch pushed to ASF repository or from developer own
+  personal fork, is left up to developer to decide.
 
 *** {Commit Message Template}
 

--- a/content/apt/developers/conventions/git.apt
+++ b/content/apt/developers/conventions/git.apt
@@ -71,6 +71,8 @@ Maven Git Convention
   from branch pushed to ASF repository or from developer own
   personal fork, is left up to developer to decide.
 
+  About definition of stable branches see {{{/project-roles.html#committers}Committer role}}.
+
 *** {Commit Message Template}
 
   Commits should be focused on one issue at a time, because that makes it easier

--- a/content/markdown/project-roles.md
+++ b/content/markdown/project-roles.md
@@ -134,11 +134,25 @@ These are those people who have been given write access to the
 Apache Maven code repository and have a signed 
 [Contributor License Agreement (CLA)][4] on file with the ASF.
 
-The Apache Maven project uses a Commit then Review policy and has
-[a number of conventions][5] which should be followed.
+Committers are responsible for ensuring that every file they
+commit is covered by a valid CLA.
 
-Committers are responsible for ensuring that every file they 
-commit is covered by a valid CLA. 
+The Apache Maven project follows both ASF commit policies as described in
+[ASF Development Process](https://www.apache.org/foundation/how-it-works/legal.html)
+document.
+
+In general, "review then commit" (RTC) is required for complex changes or against "stable" 
+branches, while "commit then review" (CTR) is allowed for the rest of changes. 
+Always inform yourself (ultimately by asking on developers mailing list) which branches 
+are considered as "stable" and which as not stable ones.
+
+Naturally, while committers have write access to code repository, nothing prevents
+them to use personal forks of project repositories, hence creating pull requests
+may happen in both ways (as both has pros and cons): from branch in project 
+repository or from personal fork as well. It is left to developer how
+he organizes his own work.
+
+Committers should also follow [a number of conventions][5].
 
 Committers who would like to become PMC members should try to find
 ways to demonstrate the responsibilities listed in the PMC Members

--- a/content/markdown/project-roles.md
+++ b/content/markdown/project-roles.md
@@ -146,6 +146,8 @@ branches, while "commit then review" (CTR) is allowed for the rest of changes.
 Always inform yourself (ultimately by asking on developers mailing list) which branches 
 are considered as "stable" and which as not stable ones.
 
+If unsure by any reason, RTC policy is to be followed (create pull request and ask for review).
+
 Naturally, while committers have write access to code repository, nothing prevents
 them to use personal forks of project repositories, hence creating pull requests
 may happen in both ways (as both has pros and cons): from branch in project 


### PR DESCRIPTION
Last update to ASF Maven commit policy happened while project sources were hosted in Subversion repository... Update relevant bits w/ respect to changes happened since then.

---

https://issues.apache.org/jira/browse/MNGSITE-491