### PR TITLE
Remove property from parameter for Map and Properties

### DIFF
--- a/content/apt/guides/mini/guide-configuring-plugins.apt
+++ b/content/apt/guides/mini/guide-configuring-plugins.apt
@@ -345,7 +345,7 @@ public class MyAnimalMojo
 
 +-----+
 ...
-    @Parameter(property = "myMap")
+    @Parameter
     private Map myMap;
 ...
 +-----+
@@ -367,7 +367,7 @@ public class MyAnimalMojo
 
 +-----+
 ...
-    @Parameter(property = "myProperties")
+    @Parameter
     private Properties myProperties;
 ...
 +-----+


### PR DESCRIPTION
There is no converters from String to Map, Properties So we can not use property for parameter of this type

Tested with Maven 3.8.6 and I have:

```
Cannot assign configuration entry 'properties' with value '${myProp}' of type java.lang.String to property of type java.util.Properties 
```

```
 Cannot assign configuration entry 'myMap' with value '${myMap}' of type java.lang.String to property of type java.util.Map
```