### PR TITLE
Fix typo in introduction-to-profiles.apt

### DIFF
--- a/content/apt/guides/introduction/introduction-to-profiles.apt
+++ b/content/apt/guides/introduction/introduction-to-profiles.apt
@@ -52,7 +52,7 @@ Introduction to Build Profiles
   However, used properly, profiles can be used while still preserving
   project portability. This will also minimize the use of <<<-f>>> option of
   maven which allows user to create another POM with different parameters or
-  configuration to build which makes it more maintainable since it is runnning
+  configuration to build which makes it more maintainable since it is running
   with one POM only.
 
 * What are the different types of profile? Where is each defined?


### PR DESCRIPTION
Fix typo on line 55. It was "runnning" (with 3 n) but it should be "running"