### PR TITLE
Reformat pom.xml using 'spotless:apply'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-site.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-site.git</developerConnection>
-    <url>https://github.com/apache/maven-site/tree/${project.scm.tag}</url>
     <tag>master</tag>
+    <url>https://github.com/apache/maven-site/tree/${project.scm.tag}</url>
   </scm>
 
   <issueManagement>
@@ -72,7 +72,8 @@
     <versions3x>3.8.7,3.8.6,3.8.5,3.8.4,3.8.3,3.8.2,3.8.1,3.6.3,3.6.2,3.6.1,3.6.0,3.5.4,3.5.3,3.5.2,3.5.0,3.5.0-beta-1,3.5.0-alpha-1,3.3.9,3.3.3,3.3.1,3.2.5,3.2.3,3.2.2,3.2.1,3.1.1,3.1.0,3.1.0-alpha-1,3.0.5,3.0.4,3.0.3,3.0.2,3.0.1,3.0,3.0-beta-3,3.0-beta-2,3.0-beta-1,3.0-alpha-7,3.0-alpha-6,3.0-alpha-5,3.0-alpha-4,3.0-alpha-3</versions3x>
     <version4x>4.0.0-alpha-3,4.0.0-alpha-2</version4x>
     <site.output>${project.build.directory}/site</site.output>
-    <fluidoVersion>1.11.1</fluidoVersion><!-- used by src/xdoc/errors/404.xml.vm -->
+    <!-- used by src/xdoc/errors/404.xml.vm -->
+    <fluidoVersion>1.11.1</fluidoVersion>
     <doxiaVersion>2.0.0-M3</doxiaVersion>
     <doxiaToolsVersion>2.0.0-M3</doxiaToolsVersion>
     <javaVersion>8</javaVersion>
@@ -80,21 +81,23 @@
   </properties>
 
   <repositories>
-    <repository><!-- useful to resolve parent pom when it is a SNAPSHOT -->
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
+    <repository>
+      <!-- useful to resolve parent pom when it is a SNAPSHOT -->
       <releases>
         <enabled>false</enabled>
       </releases>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/snapshots</url>
     </repository>
-    <repository><!-- to test with ASF staging repo -->
-      <id>apache.staging</id>
-      <name>Apache Staging Repository</name>
-      <url>https://repository.apache.org/content/repositories/maven-1752/</url>
+    <repository>
+      <!-- to test with ASF staging repo -->
       <releases>
         <enabled>true</enabled>
       </releases>
+      <id>apache.staging</id>
+      <name>Apache Staging Repository</name>
+      <url>https://repository.apache.org/content/repositories/maven-1752/</url>
     </repository>
   </repositories>
 
@@ -113,7 +116,8 @@
           <version>4.0.0-M3</version>
           <configuration>
             <siteDirectory>${siteDirectory}</siteDirectory>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
           </configuration>
           <dependencies>
             <!--
@@ -172,15 +176,17 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
-          <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+          <!-- no need for site:stage, use target/site -->
+          <content>${project.reporting.outputDirectory}</content>
         </configuration>
         <executions>
           <execution>
             <id>scm-publish</id>
-            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
             <goals>
               <goal>publish-scm</goal>
             </goals>
+            <!-- deploy site with maven-scm-publish-plugin -->
+            <phase>site-deploy</phase>
           </execution>
         </executions>
       </plugin>
@@ -210,7 +216,7 @@
               </rules>
             </configuration>
           </execution>
-<!--
+          <!--
           <execution>
             <id>check-site-inheritance</id>
             <goals>
@@ -244,15 +250,15 @@
         <executions>
           <execution>
             <id>create-security.txt-timestamp</id>
-            <phase>pre-site</phase>
             <goals>
               <goal>timestamp-property</goal>
             </goals>
+            <phase>pre-site</phase>
             <configuration>
               <name>maven.security.expires</name>
               <pattern>yyyy-MM-'01T00:00:00Z'</pattern>
               <!-- This ugly Plexus magic will be coerced in the plugin to Locale#ROOT -->
-              <locale xml:space="preserve"> </locale>
+              <locale xml:space="preserve" />
               <offset>+1</offset>
               <unit>year</unit>
             </configuration>
@@ -265,10 +271,10 @@
         <executions>
           <execution>
             <id>copy-filtered-resources</id>
-            <phase>pre-site</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
+            <phase>pre-site</phase>
             <configuration>
               <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
               <resources>
@@ -294,17 +300,17 @@
         <executions>
           <execution>
             <id>chmod</id>
-            <phase>site</phase>
             <goals>
               <goal>run</goal>
             </goals>
+            <phase>site</phase>
             <configuration>
               <target>
                 <!-- mirror cgi script: see http://www.apache.org/dev/release-download-pages.html#custom -->
-                <chmod file="${project.reporting.outputDirectory}/download.cgi" perm="ugo+rx"/>
+                <chmod file="${project.reporting.outputDirectory}/download.cgi" perm="ugo+rx" />
                 <!-- links to components directories containing releases documentation: http://maven.apache.org/developers/website/ -->
                 <symlink action="recreate" overwrite="true">
-                  <fileset dir="${project.reporting.outputDirectory}" includes="**/components.links"/>  
+                  <fileset dir="${project.reporting.outputDirectory}" includes="**/components.links" />
                 </symlink>
               </target>
             </configuration>
@@ -348,7 +354,6 @@
             </configuration>
           </execution>
         </executions>
-        
       </plugin>
 
       <plugin>
@@ -357,10 +362,10 @@
         <executions>
           <execution>
             <id>jar</id>
-            <phase>site</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>site</phase>
             <configuration>
               <jarOutputDirectory>${project.reporting.outputDirectory}</jarOutputDirectory>
               <archiveExcludes>
@@ -393,19 +398,21 @@
   </build>
 
   <reporting>
-    <excludeDefaults>true</excludeDefaults>
     <outputDirectory>${site.output}</outputDirectory>
+    <excludeDefaults>true</excludeDefaults>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <reportSets>
-          <reportSet><!-- don't execute inherited reports, since some are useless and cannot be removed -->
+          <reportSet>
+            <!-- don't execute inherited reports, since some are useless and cannot be removed -->
             <configuration>
               <skip>true</skip>
             </configuration>
           </reportSet>
-          <reportSet><!-- execute only reports necessary for main site, in a dedicated reportSet -->
+          <reportSet>
+            <!-- execute only reports necessary for main site, in a dedicated reportSet -->
             <id>site-mpir</id>
             <reports>
               <report>team</report>
@@ -435,10 +442,10 @@
             <executions>
               <execution>
                 <id>pdf</id>
-                <phase>site</phase>
                 <goals>
                   <goal>pdf</goal>
                 </goals>
+                <phase>site</phase>
                 <configuration>
                   <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
                   <siteDirectory>${project.basedir}/content</siteDirectory>


### PR DESCRIPTION
 * new pom.xml formatting rules are coming in from the parent POM. 'mvn verify' fails without these