### PR TITLE
Trivial wording fix in download page

### DIFF
--- a/content/xdoc/download.xml.vm
+++ b/content/xdoc/download.xml.vm
@@ -136,7 +136,7 @@ under the License.
           <table>
             <tr>
               <td><b>Java Development Kit (JDK)</b></td>
-              <td>Maven 4.0+ requires JDK 1.8 or above to execute - it still allow you to build against 1.3 and other JDK versions
+              <td>Maven 4.0+ requires JDK 1.8 or above to execute - it still allows you to build against 1.3 and other JDK versions
                   <a href="/guides/mini/guide-using-toolchains.html">by Using Toolchains</a></td>
             </tr>
             <tr>


### PR DESCRIPTION
 * forgotten in the previous commit 6a5780e8aa5c5ba7d76f98dd4d885e6a1bb74916

@elharo thanks for merging my previous PR so quickly!

This is a trivial fixup where I forgot to change one of the words in the Maven 4.x case.