### PR TITLE
Plugin testing: remove verifier example and instead link to verifier Getting Started guide

### DIFF
--- a/content/apt/plugin-developers/plugin-testing.apt
+++ b/content/apt/plugin-developers/plugin-testing.apt
@@ -114,72 +114,9 @@ Integration/Functional testing
 
 * maven-verifier
 
- maven-verifier tests are run using JUnit or TestNG, and provide a simple class allowing you to launch Maven and assert on its log file and built artifacts.  It also provides a ResourceExtractor, which extracts a Maven project from your src/test/resources directory into a temporary working directory where you can do tricky stuff with it.
+ maven-verifier tests are run using JUnit or TestNG, and provide a simple class allowing you to launch Maven and assert on its log file and built artifacts.  It also provides a ResourceExtractor, which extracts a Maven project from your src/test/resources directory into a temporary working directory where you can do tricky stuff with it. Follow the {{{/shared/maven-verifier/getting-started.html}Getting Started}} guide to learn more about creating maven-verifier tests.
 
  Maven itself uses maven-verifier to run its core integration tests.  For more information, please refer to {{{https://cwiki.apache.org/confluence/display/MAVEN/Creating+a+Maven+Integration+Test}Creating a Maven Integration Test}}.
-
-+-----+
-public class TrivialMavenVerifierTest extends TestCase
-{
-    public void testMyPlugin()
-        throws Exception
-    {
-        // Check in your dummy Maven project in /src/test/resources/...
-        // The testdir is computed from the location of this
-        // file.
-        File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/my-dummy-maven-project" );
-
-        Verifier verifier;
-
-        /*
-         * We must first make sure that any artifact created
-         * by this test has been removed from the local
-         * repository. Failing to do this could cause
-         * unstable test results. Fortunately, the verifier
-         * makes it easy to do this.
-         */
-        verifier = new Verifier( testDir.getAbsolutePath() );
-        verifier.deleteArtifact( "org.apache.maven.its.itsample", "parent", "1.0", "pom" );
-        verifier.deleteArtifact( "org.apache.maven.its.itsample", "checkstyle-test", "1.0", "jar" );
-        verifier.deleteArtifact( "org.apache.maven.its.itsample", "checkstyle-assembly", "1.0", "jar" );
-
-        /*
-         * The Command Line Options (CLI) are passed to the
-         * verifier as a list. This is handy for things like
-         * redefining the local repository if needed. In
-         * this case, we use the -N flag so that Maven won't
-         * recurse. We are only installing the parent pom to
-         * the local repo here.
-         */
-        List cliOptions = new ArrayList();
-        cliOptions.add( "-N" );
-        verifier.executeGoal( "install" );
-
-        /*
-         * This is the simplest way to check a build
-         * succeeded. It is also the simplest way to create
-         * an IT test: make the build pass when the test
-         * should pass, and make the build fail when the
-         * test should fail. There are other methods
-         * supported by the verifier. They can be seen here:
-         * http://maven.apache.org/shared/maven-verifier/apidocs/index.html
-         */
-        verifier.verifyErrorFreeLog();
-
-        /*
-         * Reset the streams before executing the verifier
-         * again.
-         */
-        verifier.resetStreams();
-
-        /*
-         * The verifier also supports beanshell scripts for
-         * verification of more complex scenarios. There are
-         * plenty of examples in the core-it tests here:
-         * https://svn.apache.org/repos/asf/maven/core-integration-testing/trunk
-         */
-    }
-+-----+
 
  <<Note>>: maven-verifier and maven-verifier-plugin sound similar, but are totally different unrelated pieces of code.  maven-verifier-plugin simply verifies the existence/absence of files on the filesystem.  You could use it for functional testing, but you may need more features than maven-verifier-plugin provides.
 


### PR DESCRIPTION
 * addCliOption() and resetStreams() are deprecated in the current verifier version (2.0.0-M1)