### PR TITLE
Update download page

### DIFF
--- a/content/xdoc/download.xml.vm
+++ b/content/xdoc/download.xml.vm
@@ -38,7 +38,7 @@ under the License.
           <table>
             <tr>
               <td><b>Java Development Kit (JDK)</b></td>
-              <td>Maven 3.3+ requires JDK 1.7 or above to execute. It still allows you to build against 1.3 and other JDK versions
+              <td>Maven 3.9+ requires JDK 1.8 or above to execute. It still allows you to build against 1.3 and other JDK versions
               <a href="/guides/mini/guide-using-toolchains.html">by using toolchains</a>.</td>
             </tr>
             <tr>
@@ -47,7 +47,7 @@ under the License.
             </tr>
             <tr>
               <td><b>Disk</b></td>
-              <td>Approximately 10MB is required for the Maven installation itself. In addition to that, disk space will
+              <td>Approximately 11MB is required for the Maven installation itself. In addition to that, disk space will
               be used for your local Maven repository. The size of your local repository will vary depending on usage but expect at
               least 500MB.</td>
             </tr>


### PR DESCRIPTION
Now both, latest stable Maven 3.x and Maven 4.x require Java 8, make it written so. Also, current installation size for 3.9.0 is 11MB :)