### PR TITLE
[MNG-7684] Mention `maven.config` parse change in 3.9.0 release notes

### DIFF
--- a/content/markdown/docs/3.9.0/release-notes.md
+++ b/content/markdown/docs/3.9.0/release-notes.md
@@ -43,6 +43,7 @@ If you have any questions, please consult:
 * Several backports from Maven 4.x line.
 * Long outstanding issue fixes from Maven 3.8.x line.
 * General fixes and improvements.
+* Each line in `.mvn/maven.config` is now interpreted as a single argument. That is, if the file contains multiple arguments, these must now be placed on separate lines.
 
 The full list of changes can be found in our [issue management system][4].
 


### PR DESCRIPTION
See [MNG-7684](https://issues.apache.org/jira/browse/MNG-7684) for context.