### PR TITLE
Remove currentStableReleaseDate value

### DIFF
--- a/content/markdown/developers/release/maven-core-release.md
+++ b/content/markdown/developers/release/maven-core-release.md
@@ -118,7 +118,7 @@ Edit <https://github.com/apache/maven/blob/master/doap_Maven.rdf> to list the ne
 
 Checkout Maven site source <https://github.com/apache/maven-site.git>.
 
-For 3.x: update the `versions3x`, `currentStableVersion` and `currentStableReleaseDate` properties in `pom.xml`
+For 3.x: update the `versions3x`, `currentStableVersion` and `currentStableVersionDetails` properties in `pom.xml`
 
 Next, update release history `content/markdown/docs/history.md.vm`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
   <properties>
     <maven.site.path>maven-site</maven.site.path>
     <currentStableVersion>3.9.0</currentStableVersion>
-    <currentStableReleaseDate>2023-01-31</currentStableReleaseDate>
     <currentStableVersionDetails>9b58d2bad23a66be161c4664ef21ce219c2c8584</currentStableVersionDetails>
     <current4xVersion>4.0.0-alpha-4</current4xVersion>
     <current39xVersion>3.9.0</current39xVersion>


### PR DESCRIPTION
This value was used in the days when the Maven distro included a build date.

This closes #396