### PR TITLE
document core is EOL before 3.8.8 (e.g we will not provide core release for bugs nor security issues).

### DIFF
--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -63,6 +63,11 @@ $b_</td>
 
 Date format is: YYYY-MM-DD
 
+Apache Maven supports the last version of the last 2 series of GA release.
+If last release is 3.9.1, Apache Maven project will support core versions:
+- 3.9.1
+- 3.8.7
+
 <h3><a name="Maven_40">Maven 4.0+</a></h3>
 <table>
 <tr><th>Release Date</th>
@@ -80,7 +85,7 @@ Date format is: YYYY-MM-DD
 
 </table>
 
-<h3><a name="Maven_36">Maven 3.6.3+</a></h3>
+<h3><a name="Maven_38">Maven 3.8.8+</a></h3>
 <table>
 <tr><th>Release Date</th>
 <th>Version</th>
@@ -93,18 +98,10 @@ Date format is: YYYY-MM-DD
 #release( "2023-03-14" "3.9.1" "https://lists.apache.org/thread/ppqvkt413fpsyh0kqjcr4dl5vy3m1lgg" "true" "Java 8" "2" )
 #release( "2023-01-31" "3.9.0" "https://lists.apache.org/thread/0tfr7t2j2ddbv4gjvxm47yohtk3dg6b3" "" "" "" )
 #release( "2023-03-08" "3.8.8" "announce/202303.mbox/%3C{uuid}@apache.org%3E" "true" "Java 7" "21" )
-#release( "2022-12-24" "3.8.7" "announce/202212.mbox/%3C27650d65-28f1-f3d8-472d-7d1939e1c83f@apache.org%3E" "" "" "" )
-#release( "2022-06-06" "3.8.6" "announce/202206.mbox/%3C850c94d3-c7d3-81a3-b6e2-5b6f0d268126@apache.org%3E" "" "" "" )
-#release( "2022-03-05" "3.8.5" "announce/202203.mbox/%3Cb5eab336-e5ba-73bb-1c0c-d063d919ce4d@apache.org%3E" "" "" "" )
-#release( "2021-11-14" "3.8.4" "announce/202111.mbox/%3C55867acd-a5d4-6f42-ef39-c82a4bcd9062@apache.org%3E" "" "" "" )
-#release( "2021-09-27" "3.8.3" "announce/202110.mbox/%3C8bf4d8cb-6a12-4423-f913-24ca2351b325@apache.org%3E" "" "" "" )
-#release( "2021-08-04" "3.8.2" "announce/202108.mbox/%3C85a7a3d4-c4ae-8e1e-f5c4-832017b79ca3@apache.org%3E" "" "" "" )
-#release( "2021-04-04" "3.8.1" "announce/202104.mbox/%3CMailbird-0918dc43-dc18-4008-b83b-8bc8b1528177%40apache.org%3E" "" "" "" )
-#release( "2019-11-25" "3.6.3" "announce/201911.mbox/%3CMailbird-b8a76b15-cad9-4f81-b834-17c4e8b4d6b8%40apache.org%3E" "true" "" "" )
 
 </table>
 
-<h3><a name="Maven_3">Maven before 3.6.3</a></h3>
+<h3><a name="Maven_3">Maven before 3.8.8</a></h3>
 
 <p>Maven before 3.6.3 has now reached its end of life.
 New plugin releases will require Maven 3.2.5 or later.
@@ -117,6 +114,14 @@ The following information is made available for reference.</p>
 <th>Links</th>
 </tr>
 
+#release( "2022-12-24" "3.8.7" "announce/202212.mbox/%3C27650d65-28f1-f3d8-472d-7d1939e1c83f@apache.org%3E" "" "" "" )
+#release( "2022-06-06" "3.8.6" "announce/202206.mbox/%3C850c94d3-c7d3-81a3-b6e2-5b6f0d268126@apache.org%3E" "" "" "" )
+#release( "2022-03-05" "3.8.5" "announce/202203.mbox/%3Cb5eab336-e5ba-73bb-1c0c-d063d919ce4d@apache.org%3E" "" "" "" )
+#release( "2021-11-14" "3.8.4" "announce/202111.mbox/%3C55867acd-a5d4-6f42-ef39-c82a4bcd9062@apache.org%3E" "" "" "" )
+#release( "2021-09-27" "3.8.3" "announce/202110.mbox/%3C8bf4d8cb-6a12-4423-f913-24ca2351b325@apache.org%3E" "" "" "" )
+#release( "2021-08-04" "3.8.2" "announce/202108.mbox/%3C85a7a3d4-c4ae-8e1e-f5c4-832017b79ca3@apache.org%3E" "" "" "" )
+#release( "2021-04-04" "3.8.1" "announce/202104.mbox/%3CMailbird-0918dc43-dc18-4008-b83b-8bc8b1528177%40apache.org%3E" "" "" "" )
+#release( "2019-11-25" "3.6.3" "announce/201911.mbox/%3CMailbird-b8a76b15-cad9-4f81-b834-17c4e8b4d6b8%40apache.org%3E" "true" "" "" )
 #release( "2019-08-27" "3.6.2" "announce/201909.mbox/%3CCACcefgc8DBFwq5vQ7EuZNGSeBxemz6Hd_2n%3DMV9T%3DpYgdUM5EA%40mail.gmail.com%3E" "" "" "" )
 #release( "2019-04-04" "3.6.1" "announce/201904.mbox/%3Cop.zz6k0iklkdkhrr%40desktop-2khsk44.dynamic.ziggo.nl%3E" "" "" "" )
 #release( "2018-10-24" "3.6.0" "announce/201811.mbox/%3C20181101115259.168F4187BA%40minotaur.apache.org%3E" "" "" "" )

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -80,7 +80,7 @@ Date format is: YYYY-MM-DD
 
 </table>
 
-<h3><a name="Maven_32">Maven 3.2.5+</a></h3>
+<h3><a name="Maven_36">Maven 3.6.3+</a></h3>
 <table>
 <tr><th>Release Date</th>
 <th>Version</th>
@@ -101,6 +101,22 @@ Date format is: YYYY-MM-DD
 #release( "2021-08-04" "3.8.2" "announce/202108.mbox/%3C85a7a3d4-c4ae-8e1e-f5c4-832017b79ca3@apache.org%3E" "" "" "" )
 #release( "2021-04-04" "3.8.1" "announce/202104.mbox/%3CMailbird-0918dc43-dc18-4008-b83b-8bc8b1528177%40apache.org%3E" "" "" "" )
 #release( "2019-11-25" "3.6.3" "announce/201911.mbox/%3CMailbird-b8a76b15-cad9-4f81-b834-17c4e8b4d6b8%40apache.org%3E" "true" "" "" )
+
+</table>
+
+<h3><a name="Maven_3">Maven before 3.6.3</a></h3>
+
+<p>Maven before 3.6.3 has now reached its end of life.
+New plugin releases will require Maven 3.2.5 or later.
+The following information is made available for reference.</p>
+
+<table>
+<tr><th>Release Date</th>
+<th>Version</th>
+<th>Required Java Version</th>
+<th>Links</th>
+</tr>
+
 #release( "2019-08-27" "3.6.2" "announce/201909.mbox/%3CCACcefgc8DBFwq5vQ7EuZNGSeBxemz6Hd_2n%3DMV9T%3DpYgdUM5EA%40mail.gmail.com%3E" "" "" "" )
 #release( "2019-04-04" "3.6.1" "announce/201904.mbox/%3Cop.zz6k0iklkdkhrr%40desktop-2khsk44.dynamic.ziggo.nl%3E" "" "" "" )
 #release( "2018-10-24" "3.6.0" "announce/201811.mbox/%3C20181101115259.168F4187BA%40minotaur.apache.org%3E" "" "" "" )
@@ -114,22 +130,6 @@ Date format is: YYYY-MM-DD
 #release( "2015-04-28" "3.3.3" "users/201504.mbox/%3C4B6DEAE5-A0C1-40F0-A290-FAF9B67753D2%40takari.io%3E" "" "" "" )
 #release( "2015-03-18" "3.3.1" "users/201503.mbox/%3CC490F64B-BB4A-48F9-98DD-4352A7FAE378%40takari.io%3E" "" "" "" )
 #release( "2014-12-20" "3.2.5" "users/201412.mbox/%3C4CD625DB-6BC8-4BAE-8ABA-0A185CF81596%40apache.org%3E" "true" "Java 6" "1" )
-
-</table>
-
-<h3><a name="Maven_3">Maven before 3.2.5</a></h3>
-
-<p>Maven before 3.2.5 has now reached its end of life.
-New plugin releases will require Maven 3.2.5 or later.
-The following information is made available for reference.</p>
-
-<table>
-<tr><th>Release Date</th>
-<th>Version</th>
-<th>Required Java Version</th>
-<th>Links</th>
-</tr>
-
 #release( "2014-08-17" "3.2.3" "users/201408.mbox/%3C18823F7B-09E9-43D3-9E32-F0F3F356E844%40maven.org%3E" "true" "Java 6" "3" )
 #release( "2014-06-26" "3.2.2" "users/201406.mbox/%3CBF05670C-F811-42E0-ABBE-34A93F78BC72%40takari.io%3E" "" "" "" )
 #release( "2014-02-21" "3.2.1" "users/201402.mbox/%3C2828F75B-F636-478A-A958-404672FFA1C7%40takari.io%3E" "" "" "" )

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -61,12 +61,14 @@ $b_</td>
 
 ## Maven Releases History
 
-Date format is: YYYY-MM-DD
-
 Apache Maven supports the last version of the last 2 series of GA release.
 If last release is 3.9.1, Apache Maven project will support core versions:
 - 3.9.1
 - 3.8.7
+
+Currently, plugins support Maven API compatibility down to 3.2.5.
+
+Date format is: YYYY-MM-DD
 
 <h3><a name="Maven_40">Maven 4.0+</a></h3>
 <table>

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -61,7 +61,7 @@ $b_</td>
 
 ## Maven Releases History
 
-Apache Maven supports the last version of the last 2 series of GA release.
+Apache Maven supports the last version of the last two series of GA releases.
 If last release is 3.9.1, Apache Maven project will support core versions:
 - 3.9.1
 - 3.8.7

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -61,12 +61,12 @@ $b_</td>
 
 ## Maven Releases History
 
-Apache Maven supports the last version of the last two series of GA releases.
-If last release is 3.9.1, Apache Maven project will support core versions:
+The Apache Maven team maintains the last version of the last two series of GA releases.
+If last release is 3.9.1, the Apache Maven team project will maintains core versions:
 - 3.9.1
 - 3.8.7
 
-Currently, plugins support Maven API compatibility down to 3.2.5.
+Currently, plugins provides Maven API compatibility down to 3.2.5.
 
 Date format is: YYYY-MM-DD
 

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -62,7 +62,7 @@ $b_</td>
 ## Maven Releases History
 
 The Apache Maven team maintains the last version of the last two series of GA releases.
-If last release is 3.9.1, the Apache Maven team project will maintains core versions:
+If last release is 3.9.1, the Apache Maven team project will maintain core versions:
 - 3.9.1
 - 3.8.7
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M6</version>
+          <version>4.0.0-M7</version>
           <configuration>
             <siteDirectory>${siteDirectory}</siteDirectory>
             <!-- don't deploy site with maven-site-plugin -->


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
