### PR TITLE
Remove maven.projectBasedir properties from configuration

### DIFF
--- a/content/markdown/configure.md
+++ b/content/markdown/configure.md
@@ -39,7 +39,12 @@ configuration for Maven usage across projects.
 
 ## `.mvn` directory:
 
-Located within the project's top level directory, the files `maven.config`, `jvm.config`, and `extensions.xml`
+Located within the project's **top level directory**, the files 
+
+ - `maven.config`
+ - `jvm.config`
+ - `extensions.xml`
+
 contain project specific configuration for running Maven.
 
 This directory is part of the project and may be checked in into your version control.
@@ -52,7 +57,7 @@ who likes to use this needed to change it’s installation and makes the on-boar
 option was to give the path to the jar on command line via `mvn -Dmaven.ext.class.path=extension.jar`. This has the drawback giving those 
 options to your Maven build every time you are calling Maven. Not very convenient as well.
 
-From now on this can be done much more simpler and in a more Maven like way. So you can define an `${maven.projectBasedir}/.mvn/extensions.xml` file which looks like the following:
+From now on this can be done much more simpler and in a more Maven like way. So you can define an `.mvn/extensions.xml` file which looks like the following:
 
 ```xml
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -71,12 +76,12 @@ Now you can simply use an extension by defining the usual maven coordinates grou
 
 It’s really hard to define a general set of options for calling the maven command line. Starting with Maven 3.3.1+, this can be solved by 
 putting this 
-options to a script but this can now simple being done by defining `${maven.projectBasedir}/.mvn/maven.config` file which contains the 
+options to a script but this can now simple being done by defining `.mvn/maven.config` file which contains the 
 configuration options for the `mvn` command line. 
 
 For example things like `-T3 -U --fail-at-end`. So you only have to call Maven just by using `mvn 
 clean package` instead of `mvn -T3 -U --fail-at-end clean package` and not to miss the `-T3 -U --fail-at-end` options on every call. 
-The `${maven.projectBasedir}/.mvn/maven.config` is located in the `${maven.projectBasedir}/.mvn/` directory; also works if in the root of a multi module build.
+The `.mvn/maven.config` is located in the project's top level `.mvn` directory also works if in the root of a multi module build.
 
 **NOTICE** starting with Maven **3.9.0** each single argument must be put in new line, so for the mentioned example your file will have content like:
 
@@ -88,7 +93,11 @@ The `${maven.projectBasedir}/.mvn/maven.config` is located in the `${maven.proje
 
 ### `.mvn/jvm.config` file:
 
-Starting with Maven 3.3.1+ you can define JVM configuration via `${maven.projectBasedir}/.mvn/jvm.config` file which means you can define the options for your build on a per project base. This file will become part of your project and will be checked in along with your project. So no need anymore for `MAVEN_OPTS`, `.mavenrc` files. So for example if you put the following JVM options into the `${maven.projectBasedir}/.mvn/jvm.config` file
+Starting with Maven 3.3.1+ you can define JVM configuration via `.mvn/jvm.config` file which means you can define the options for your build on a per project base. 
+This file will become part of your project and will be checked in along with your project. 
+So no need anymore for `MAVEN_OPTS`, `.mavenrc` files. 
+
+So for example if you put the following JVM options into the `.mvn/jvm.config` file
 
 ```
 -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true

--- a/content/markdown/docs/3.3.1/release-notes.md
+++ b/content/markdown/docs/3.3.1/release-notes.md
@@ -86,7 +86,7 @@ The new [Maven 3.3.1 Release is just out](http://mail-archives.apache.org/mod_mb
   options to your Maven build every time you are calling Maven. Not very convenient as well.
 
 * From now on this can be done much more simpler and in a more Maven like way. So
-  you can define an `${maven.projectBasedir}/.mvn/extensions.xml` file which looks
+  you can define an `.mvn/extensions.xml` file in the project's top level directory which looks
   like the following:
 
 ``` xml
@@ -105,7 +105,7 @@ The new [Maven 3.3.1 Release is just out](http://mail-archives.apache.org/mod_mb
    transitive dependencies of those extensions will automatically being downloaded
    from your repository. So no need to create a shaded artifact anymore.
 
-   An other advantage is that the `${maven.projectBasedir}/.mvn/`
+   An other advantage is that the `.mvn/`
    directory is located in the root of your Maven project and in conseuqence
    is part of your project which means you will check it in along with
    your project. So everyone who checks out your project automatically
@@ -122,12 +122,12 @@ The new [Maven 3.3.1 Release is just out](http://mail-archives.apache.org/mod_mb
 * It's really hard to define a general set of options for calling the maven
   command line. Usually this will be solved by putting this options to a script
   but this can now simple being done by defining
-  `${maven.projectBasedir}/.mvn/maven.config` file which contains the
+  `.mvn/maven.config` file which contains the
   configuration options for the command line. For example things like `-T3 -U
   --fail-at-end`. So you only have to call maven just by using `mvn clean
   package` instead of `mvn -T3 -U --fail-at-end clean package` and not to miss
-  the `-T3 -U --fail-at-end` options. The `${maven.projectBasedir}/.mvn/maven.config`
-  is located in the `${maven.projectBasedir}/.mvn/` directory which is in the root
+  the `-T3 -U --fail-at-end` options. The `.mvn/maven.config`
+  is located in the `.mvn` directory which is in the root
   of a multi module build. This directory is part of the project and will be checked
   in into your version control. This results in being picked by everybody who
   checks out the project and no need to remember to call this project
@@ -139,11 +139,11 @@ The new [Maven 3.3.1 Release is just out](http://mail-archives.apache.org/mod_mb
   option with the drawback of not being part of the project.
 
 * Starting with this release you can define JVM configuration via
-  `${maven.projectBasedir}/.mvn/jvm.config` file which means you can define the
+  `.mvn/jvm.config` file which means you can define the
   options for your build on a per project base. This file will become part of
   your project and will be checked in along with your project. So no need anymore
   for `MAVEN_OPTS`, `.mavenrc` files. So for example if you put the following JVM
-  options into the `${maven.projectBasedir}/.mvn/jvm.config` file
+  options into the `.mvn/jvm.config` file
 
 ```
 -Xmx2048m -Xms1024m -XX:MaxPermSize=512m -Djava.awt.headless=true

--- a/content/markdown/docs/3.3.9/release-notes.md
+++ b/content/markdown/docs/3.3.9/release-notes.md
@@ -126,7 +126,7 @@ Bugs
    `MAVEN_OPTS` and debugging options which has been fixed by [MNG-5813][MNG-5813].
 
  * Since Maven 3.3.1 it is possible to have configurations stored on a per project base in the
-   `${maven.projectBasedir}/.mvn` directory of the project. There you can use the `maven.config`
+   `.mvn` directory of the project. There you can use the `maven.config`
    file to store command line options instead of repeating them every time you call Maven.
    In cases where this file has been empty Maven ended with a failure. This has been fixed
    with [MNG-5816][MNG-5816].

--- a/content/markdown/reference/maven-classloading.md
+++ b/content/markdown/reference/maven-classloading.md
@@ -39,7 +39,7 @@ Each core extension is loaded in a separate classloader and there is no mechanis
 
 Core extension can use `META-INF/maven/extension.xml` descriptor to declare packages and artifacts exported by the extension. If the descriptor is not present, no packages or artifacts are exported, but the extension can still contribute components to Maven Core extension points.
 
-Core extensions are configured in `${maven.projectBasedir}/.mvn/extensions.xml` configuration file.
+Core extensions are configured `.mvn/extensions.xml` configuration file in the project's top level.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
There is no such property in code .... only similar I can find in `mvn` script

```
exec "$JAVACMD" \
....
  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
  ${CLASSWORLDS_LAUNCHER} ${MAVEN_ARGS} "$@"
```

In documentation it is only used in context of `.mvn` directory,
so to not make users confused better will be remove it at all and replace by description that `.mvn` is placed in project's top level directory