### PR TITLE
Rename basedir to project.basedir

### DIFF
--- a/content/apt/guides/getting-started/index.apt
+++ b/content/apt/guides/getting-started/index.apt
@@ -225,7 +225,7 @@ my-app
 
  As you can see, the project created from the archetype has a POM, a source tree for your application's sources and
  a source tree for your test sources. This is the standard layout for Maven projects (the application sources
- reside in <<<$\{basedir\}/src/main/java>>> and test sources reside in <<<$\{basedir\}/src/test/java>>>, where $\{basedir\}
+ reside in <<<$\{project.basedir\}/src/main/java>>> and test sources reside in <<<$\{project.basedir\}/src/test/java>>>, where $\{project.basedir\}
  represents the directory containing <<<pom.xml>>>).
 
  If you were to create a Maven project by hand this is the directory structure that we recommend using. This is a
@@ -272,7 +272,7 @@ mvn compile
  the output above, it took almost 4 minutes).  If you execute the command again, Maven will now have what it needs,
  so it won't need to download anything new and will be able to execute the command much more quickly.
 
- As you can see from the output, the compiled classes were placed in <<<$\{basedir\}/target/classes>>>, which is
+ As you can see from the output, the compiled classes were placed in <<<$\{project.basedir\}/target/classes>>>, which is
  another standard convention employed by Maven. So, if you're a keen observer, you'll notice that by using the
  standard conventions, the POM above is very small and you haven't had to tell Maven explicitly where any of
  your sources are or where the output should go. By following the standard Maven conventions, you can get
@@ -364,7 +364,7 @@ mvn test
 mvn package
 ------
 
- You can now take a look in the <<<$\{basedir\}/target>>> directory and you will see the generated JAR file.
+ You can now take a look in the <<<$\{project.basedir\}/target>>> directory and you will see the generated JAR file.
 
  Now you'll want to install the artifact you've generated (the JAR file) in your local repository
  (<<<$\{user.home\}/.m2/repository>>> is the default location). For more information on repositories you can refer to our
@@ -539,9 +539,9 @@ mvn clean
  standard Maven conventions you can package resources within JARs simply by placing those resources in a standard
  directory structure.
 
- You see below in our example we have added the directory <<<$\{basedir\}/src/main/resources>>> into which we place
+ You see below in our example we have added the directory <<<$\{project.basedir\}/src/main/resources>>> into which we place
  any resources we wish to package in our JAR. The simple rule employed by Maven is this: any directories or files
- placed within the <<<$\{basedir\}/src/main/resources>>> directory are packaged in your JAR with the exact same
+ placed within the <<<$\{project.basedir\}/src/main/resources>>> directory are packaged in your JAR with the exact same
  structure starting at the base of the JAR.
 
 ----
@@ -584,7 +584,7 @@ my-app
             `-- App.class
 ----
 
- As you can see, the contents of <<<$\{basedir\}/src/main/resources>>> can be found starting at the base of the
+ As you can see, the contents of <<<$\{project.basedir\}/src/main/resources>>> can be found starting at the base of the
  JAR and our <<<application.properties>>> file is there in the <<<META-INF>>> directory. You will also notice some other files there
  like <<<META-INF/MANIFEST.MF>>> as well as a <<<pom.xml>>> and <<<pom.properties>>> file. These come standard with
  generation of a JAR in Maven. You can create your own manifest if you choose, but Maven will generate one by
@@ -604,7 +604,7 @@ artifactId=my-app
 ----
 
  To add resources to the classpath for your unit tests, you follow the same pattern as you do for adding resources to the JAR
- except the directory you place resources in is $\{basedir\}/src/test/resources. At this point you would have a
+ except the directory you place resources in is $\{project.basedir\}/src/test/resources. At this point you would have a
  project directory structure that would look like the following:
 
 -----

--- a/content/apt/guides/mini/guide-attached-tests.apt
+++ b/content/apt/guides/mini/guide-attached-tests.apt
@@ -29,7 +29,7 @@
 Guide to using attached tests
 
  You can reuse the tests that you have created for one project in another. For example, suppose
- <<<foo-core>>> contains test code in the <<<$\{basedir\}/src/test/java>>>. To package
+ <<<foo-core>>> contains test code in the <<<$\{project.basedir\}/src/test/java>>>. To package
  up those compiled tests in a JAR and deploy them for general reuse, configure the
  <<<maven-jar-plugin>>> as follows:
 

--- a/content/apt/guides/mini/guide-site.apt
+++ b/content/apt/guides/mini/guide-site.apt
@@ -53,7 +53,7 @@ Creating a site
       +- site.xml
 --------------------
 
- You will notice there is now a <<<$\{basedir\}/src/site>>> directory within which is contained a <<<site.xml>>> site descriptor
+ You will notice there is now a <<<$\{project.basedir\}/src/site>>> directory within which is contained a <<<site.xml>>> site descriptor
  along with various directories corresponding to the supported document types.
  
  Let's take a look at the examples of the various document types:

--- a/content/apt/guides/mini/guide-snippet-macro.apt
+++ b/content/apt/guides/mini/guide-snippet-macro.apt
@@ -103,7 +103,7 @@ Guide to the Snippet Macro
 
   As of doxia-core version 1.0-alpha-9, a 'file' parameter is also available.
   If a full path is not specified, the location is assumed to be relative to
-  $\{basedir\}.
+  $\{project.basedir\}.
 
 +------
  ~~ Since doxia-core 1.0-alpha-9

--- a/content/apt/plugin-developers/common-bugs.apt
+++ b/content/apt/plugin-developers/common-bugs.apt
@@ -309,7 +309,7 @@ public MyMojo extends AbstractMojo
 
   It is common practice for users of Maven to specify relative paths in the POM, not to mention that the Super POM does
   so, too. The intention is to resolve such relative paths against the base directory of the current project. In other
-  words, the paths <<<target/classes>>> and <<<$\{basedir\}/target/classes>>> should resolve to the same directory for a
+  words, the paths <<<target/classes>>> and <<<$\{project.basedir\}/target/classes>>> should resolve to the same directory for a
   given POM.
 
   Unfortunately, the class <<<{{{http://java.sun.com/javase/6/docs/api/java/io/File.html}java.io.File}}>>> does not

--- a/content/apt/plugin-developers/cookbook/plexus-plugin-upgrade.apt
+++ b/content/apt/plugin-developers/cookbook/plexus-plugin-upgrade.apt
@@ -73,12 +73,12 @@ Cookbook: How To Upgrade from Plexus Javadoc Tags to Plexus Java Annotations?
 || goals  | {{{https://codehaus-plexus.github.io/plexus-maven-plugin/descriptor-mojo.html}<<<descriptor>>>}}        | {{{https://codehaus-plexus.github.io/plexus-containers/plexus-component-metadata/generate-metadata-mojo.html}<<<generate-metadata>>>}}
 *---------+---------------------------------------------------------------------------------------------------------+--------------+
 |         | {{{https://codehaus-plexus.github.io/plexus-maven-plugin/merge-descriptors-mojo.html}<<<merge-descriptors>>>}} | see <<<staticMetadataDirectory>>> parameter \
-|         |                                                                                                         | default: <<<$\{basedir}/src/main/resources/META-INF/plexus>>>
+|         |                                                                                                         | default: <<<$\{project.basedir}/src/main/resources/META-INF/plexus>>>
 *---------+---------------------------------------------------------------------------------------------------------+--------------+
 |         | {{{https://codehaus-plexus.github.io/plexus-maven-plugin/test-descriptor-mojo.html}<<<test-descriptor>>>}} | {{{https://codehaus-plexus.github.io/plexus-containers/plexus-component-metadata/generate-test-metadata-mojo.html}<<<generate-test-metadata>>>}}
 *---------+---------------------------------------------------------------------------------------------------------+--------------+
 |         | {{{https://codehaus-plexus.github.io/plexus-maven-plugin/test-merge-descriptors-mojo.html}<<<test-merge-descriptors>>>}} | see <<<testStaticMetadataDirectory>>> parameter \
-|         |                                                                                                         | default: <<<$\{basedir}/src/test/resources/META-INF/plexus>>>
+|         |                                                                                                         | default: <<<$\{project.basedir}/src/test/resources/META-INF/plexus>>>
 *---------+---------------------------------------------------------------------------------------------------------+--------------+
 |         | {{{https://codehaus-plexus.github.io/plexus-maven-plugin/components-report-mojo.html}<<<components-report>>>}} | reporting feature not available
 *---------+---------------------------------------------------------------------------------------------------------+--------------+
@@ -139,7 +139,7 @@ Cookbook: How To Upgrade from Plexus Javadoc Tags to Plexus Java Annotations?
 </project>
 +---------+
 
- If <<<merge-descriptors>>> is used, move the handwritten xml file to <<<$\{basedir}/src/main/resources/META-INF/plexus>>>.
+ If <<<merge-descriptors>>> is used, move the handwritten xml file to <<<$\{project.basedir}/src/main/resources/META-INF/plexus>>>.
 
 ** Replacing Plexus Javadoc Tags with Plexus Java 5 Annotations
 

--- a/content/apt/pom.apt.vm
+++ b/content/apt/pom.apt.vm
@@ -822,7 +822,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 -------------------------------
 <build>
   <defaultGoal>install</defaultGoal>
-  <directory>${basedir}/target</directory>
+  <directory>${project.basedir}/target</directory>
   <finalName>${artifactId}-${version}</finalName>
   <filters>
     <filter>filters/filter1.properties</filter>
@@ -837,7 +837,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 
   * <<directory>>:
   This is the directory where the build will dump its files or, in Maven parlance, the build's target.
-  It aptly defaults to <<<$\{basedir\}/target>>>.
+  It aptly defaults to <<<$\{project.basedir\}/target>>>.
 
   * <<finalName>>:
   This is the name of the bundled project when it is finally built (sans the file extension, for
@@ -852,7 +852,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   accept their settings (covered below). In other words, the "<<<name=value>>>" pairs defined within
   the filter files replace <<<$\{name\}>>> strings within resources on build. The example above defines
   the <<<filter1.properties>>> file under the <<<filters/>>> directory. Maven's default filter
-  directory is <<<$\{basedir\}/src/main/filters/>>>.
+  directory is <<<$\{project.basedir\}/src/main/filters/>>>.
 
   For a more comprehensive look at what filters are and what they can do, take a look at the
   {{{./guides/getting-started}quick start guide}}.
@@ -878,7 +878,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
       <resource>
         <targetPath>META-INF/plexus</targetPath>
         <filtering>false</filtering>
-        <directory>${basedir}/src/main/plexus</directory>
+        <directory>${project.basedir}/src/main/plexus</directory>
         <includes>
           <include>configuration.xml</include>
         </includes>
@@ -911,7 +911,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 
   * <<directory>>:
   This element's value defines where the resources are to be found. The default directory for a build is
-  <<<$\{basedir\}/src/main/resources>>>.
+  <<<$\{project.basedir\}/src/main/resources>>>.
 
   * <<includes>>:
   A set of files patterns which specify the files to include as resources under that specified directory, using *
@@ -925,7 +925,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   The <<<testResources>>> element block contains <<<testResource>>>
   elements. Their definitions are similar to <<<resource>>> elements, but are naturally used during test
   phases. The one difference is that the default (Super POM defined) test resource directory for a project is
-  <<<$\{basedir\}/src/test/resources>>>. Test resources are not deployed.
+  <<<$\{project.basedir\}/src/test/resources>>>. Test resources are not deployed.
 
 *** {Plugins}
 
@@ -1239,11 +1239,11 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   ...
   <build>
-    <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
-    <scriptSourceDirectory>${basedir}/src/main/scripts</scriptSourceDirectory>
-    <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
-    <outputDirectory>${basedir}/target/classes</outputDirectory>
-    <testOutputDirectory>${basedir}/target/test-classes</testOutputDirectory>
+    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+    <scriptSourceDirectory>${project.basedir}/src/main/scripts</scriptSourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
+    <outputDirectory>${project.basedir}/target/classes</outputDirectory>
+    <testOutputDirectory>${project.basedir}/target/test-classes</testOutputDirectory>
     ...
   </build>
 </project>
@@ -1251,7 +1251,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 
   If the values of a <<<*Directory>>> element above is set as an absolute path (when their
   properties are expanded) then that directory is used. Otherwise, it is relative to the
-  base build directory: <<<$\{basedir\}>>>. <<Please note that the>> <<<scriptSourceDirectory>>> <<is nowhere
+  base build directory: <<<$\{project.basedir\}>>>. <<Please note that the>> <<<scriptSourceDirectory>>> <<is nowhere
   used in Maven and is obsolete>>.
 
 *** {Extensions}
@@ -1305,7 +1305,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   ...
   <reporting>
-    <outputDirectory>${basedir}/target/site</outputDirectory>
+    <outputDirectory>${project.basedir}/target/site</outputDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
@@ -1321,7 +1321,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 +------------------------------------------+
 
   The other difference is the <<<outputDirectory>>> element under <<<plugin>>>. In the case of reporting,
-  the output directory is <<<$\{basedir\}/target/site>>> by default.
+  the output directory is <<<$\{project.basedir\}/target/site>>> by default.
 
 ** {Report Sets}
 

--- a/content/markdown/faq-unoffical.md
+++ b/content/markdown/faq-unoffical.md
@@ -1041,7 +1041,7 @@ NOTE: this may only work in the latest plugin version in SVN
                         <path refid="maven.compile.classpath"/>
                         <path refid="maven.plugin.classpath"/>
                     </path>
-                    <ant antfile="${basedir}/build.xml" dir="${basedir}" inheritRefs="true">
+                    <ant antfile="${project.basedir}/build.xml" dir="${project.basedir}" inheritRefs="true">
                         <target name="generate-sources"/>
                     </ant>
                 </tasks>


### PR DESCRIPTION
We should consequently use one property name

changed pages by replace in IDE:

https://maven.apache.org/guides/getting-started/index.html
https://maven.apache.org/guides/mini/guide-attached-tests.html
https://maven.apache.org/guides/mini/guide-site.html
https://maven.apache.org/guides/mini/guide-snippet-macro.html
https://maven.apache.org/plugin-developers/common-bugs.html
https://maven.apache.org/plugin-developers/cookbook/plexus-plugin-upgrade.html
https://maven.apache.org/pom.html

https://maven.apache.org/faq-unoffical.html - not linked anywhere, content is broken, I don't fix it 😄 