### PR TITLE
Use puml to generate sources diagrams

### DIFF
--- a/content/xdoc/scm.xml
+++ b/content/xdoc/scm.xml
@@ -64,6 +64,16 @@ repo start master --all</pre>
       </subsection>
 
       <subsection name="Maven Sources Overview">
+        <p>
+          <object type="image/svg+xml" data="maven-sources/site.svg"/>
+        </p>
+        <p>
+          <object type="image/svg+xml" data="maven-sources/core.svg"/>
+        </p>
+        <p>
+          <object type="image/svg+xml" data="maven-sources/plugins.svg"/>
+        </p>
+
         <p align="center">
           <img src="maven-sources.png" width="843" height="837" border="0" usemap="#maven-sources" />
           <map name="maven-sources">

--- a/content/xdoc/scm.xml
+++ b/content/xdoc/scm.xml
@@ -73,6 +73,12 @@ repo start master --all</pre>
         <p>
           <object type="image/svg+xml" data="maven-sources/plugins.svg"/>
         </p>
+        <p>
+          <object type="image/svg+xml" data="maven-sources/doxia.svg"/>
+        </p>
+        <p>
+          <object type="image/svg+xml" data="maven-sources/misc.svg"/>
+        </p>
 
         <p align="center">
           <img src="maven-sources.png" width="843" height="837" border="0" usemap="#maven-sources" />

--- a/src/plantuml/maven-sources/core.puml
+++ b/src/plantuml/maven-sources/core.puml
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+@startuml
+!pragma layout smetana
+
+skinparam rectangle {
+  BackgroundColor LightBlue
+}
+
+package "Maven Core" {
+  rectangle Maven
+  rectangle "Core ITs"
+  rectangle Resolver
+  rectangle "Ant Tasks"
+}
+
+'hidden dependencies to change layout
+Maven -[hidden]> "Core ITs"
+"Core ITs" -[hidden]> Resolver
+Resolver -[hidden]> "Ant Tasks"
+
+url of Maven is [[https://github.com/apache/maven]]
+url of "Core ITs" is [[https://github.com/apache/maven-integration-testing]]
+url of Resolver is [[https://github.com/apache/maven-resolver]]
+url of "Ant Tasks" is [[https://github.com/maven-resolver-ant-tasks]]
+
+@enduml

--- a/src/plantuml/maven-sources/doxia.puml
+++ b/src/plantuml/maven-sources/doxia.puml
@@ -23,21 +23,21 @@ skinparam rectangle {
   BackgroundColor LightBlue
 }
 
-package "Maven Core" {
-  rectangle Maven
-  rectangle "Core ITs"
-  rectangle Resolver
-  rectangle "Ant Tasks"
+package "Maven Doxia" {
+  rectangle Doxia
+  rectangle "Site Tools"
+  rectangle Site #LightGrey
+  package Tools {
+    rectangle Converter
+    rectangle LinkCheck
+  }
 }
 
 'hidden dependencies to change layout
-Maven -[hidden]right-> "Core ITs"
-"Core ITs" -[hidden]right-> Resolver
-Resolver -[hidden]right-> "Ant Tasks"
+Doxia -[hidden]right-> "Site Tools"
+"Site Tools" -[hidden]right-> Site
+"Site Tools" -[hidden]right-> Tools
 
-url of Maven is [[https://github.com/apache/maven]]
-url of "Core ITs" is [[https://github.com/apache/maven-integration-testing]]
-url of Resolver is [[https://github.com/apache/maven-resolver]]
-url of "Ant Tasks" is [[https://github.com/maven-resolver-ant-tasks]]
+'url of "Ant Tasks" is [[https://github.com/maven-resolver-ant-tasks]]
 
 @enduml

--- a/src/plantuml/maven-sources/misc.puml
+++ b/src/plantuml/maven-sources/misc.puml
@@ -23,21 +23,32 @@ skinparam rectangle {
   BackgroundColor LightBlue
 }
 
-package "Maven Core" {
-  rectangle Maven
-  rectangle "Core ITs"
-  rectangle Resolver
-  rectangle "Ant Tasks"
+package Misc {
+  rectangle Archetypes
+  rectangle Poms
+  rectangle Skins
+  rectangle Studies
+  rectangle Indexer
+  rectangle Wagon
+  rectangle "Plugin testing"
+  rectangle "dist-tool"
+  package Jenkins {
+    rectangle env
+    rectangle lib
+  }
 }
 
 'hidden dependencies to change layout
-Maven -[hidden]right-> "Core ITs"
-"Core ITs" -[hidden]right-> Resolver
-Resolver -[hidden]right-> "Ant Tasks"
+Archetypes -[hidden]right-> Poms
+Poms -[hidden]right-> Skins
+Skins -[hidden]right-> Studies
+Studies -[hidden]right-> Indexer
+Indexer -[hidden]right-> Wagon
+Wagon -[hidden]right-> "Plugin testing"
 
-url of Maven is [[https://github.com/apache/maven]]
-url of "Core ITs" is [[https://github.com/apache/maven-integration-testing]]
-url of Resolver is [[https://github.com/apache/maven-resolver]]
-url of "Ant Tasks" is [[https://github.com/maven-resolver-ant-tasks]]
+Archetypes -[hidden]down-> "dist-tool"
+"dist-tool" -[hidden]right-> Jenkins
+
+'url of "Ant Tasks" is [[https://github.com/maven-resolver-ant-tasks]]
 
 @enduml

--- a/src/plantuml/maven-sources/plugins.puml
+++ b/src/plantuml/maven-sources/plugins.puml
@@ -1,0 +1,116 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+@startuml
+!pragma layout smetana
+
+skinparam rectangle {
+  BackgroundColor LightBlue
+}
+
+
+package Plugins {
+
+  package Core {
+    rectangle clean
+    rectangle compiler
+    rectangle deploy
+    rectangle install
+    rectangle resources
+    rectangle site
+    rectangle surefire
+    rectangle verifier
+  }
+
+  package Packaging {
+    rectangle ear
+    rectangle ejb
+    rectangle jar
+    rectangle rar
+    rectangle war
+    rectangle acr
+    rectangle shade
+    rectangle source
+    rectangle jlink
+    rectangle jmod
+  }
+
+  package Reporting {
+    rectangle changelog
+    rectangle changes
+    rectangle checkstyle
+    rectangle doap
+    rectangle javadoc
+    rectangle jdeps
+    rectangle jxr
+    rectangle linkcheck
+    rectangle pmd
+    rectangle "project-info-reports"
+  }
+
+  package Tools {
+    rectangle antrun
+    rectangle archetype
+    rectangle assembly
+    rectangle dependency
+    rectangle enforcer
+    rectangle gpg
+    rectangle help
+    rectangle invoker
+    rectangle jarsigner
+    rectangle jdeprscan
+    rectangle patch
+    rectangle pdf
+    rectangle plugin
+    rectangle release
+    rectangle "remote-resource"
+    rectangle scm
+    rectangle "scm-ppublish"
+    rectangle scripting
+    rectangle stage
+    rectangle toolchains
+  }
+}
+
+'hidden dependencies to change layout
+Core      -[hidden]-> Packaging
+Packaging -[hidden]-> Reporting
+Reporting -[hidden]-> Tools
+
+clean     -[hidden]> compiler
+compiler  -[hidden]> deploy
+deploy    -[hidden]> install
+install   -[hidden]> resources
+resources -[hidden]> site
+site      -[hidden]> surefire
+surefire  -[hidden]> verifier
+
+ear       -[hidden]> ejb
+ejb       -[hidden]> jar
+jar       -[hidden]> rar
+rar       -[hidden]> war
+war       -[hidden]> acr
+acr       -[hidden]> shade
+shade     -[hidden]> source
+source    -[hidden]> jlink
+jlink     -[hidden]> jmod
+
+
+url of clean is [[https://github.com/apache/maven-clean-plugin]]
+
+@enduml

--- a/src/plantuml/maven-sources/plugins.puml
+++ b/src/plantuml/maven-sources/plugins.puml
@@ -80,7 +80,7 @@ package Plugins {
     rectangle release
     rectangle "remote-resource"
     rectangle scm
-    rectangle "scm-ppublish"
+    rectangle "scm-publish"
     rectangle scripting
     rectangle stage
     rectangle toolchains

--- a/src/plantuml/maven-sources/site.puml
+++ b/src/plantuml/maven-sources/site.puml
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+@startuml
+!pragma layout smetana
+
+rectangle Site
+rectangle Sources #LightBlue
+
+url of Site is [[https://github.com/apache/maven-site]]
+url of Sources is [[https://github.com/apache/maven-sources]]
+
+@enduml


### PR DESCRIPTION
We have diagram of Maven sources repositories: https://maven.apache.org/scm.html
https://maven.apache.org/maven-sources.png

I don't see a way to easy edit this png file .... so I try to use a puml for generate it.

The result can look like:

![image](https://github.com/apache/maven-site/assets/3578921/734b757b-050f-48d2-b74a-d2a5d34377df)

Links in puml also working 😄 

If you like it I will continue work.