### PR TITLE
[MNGSITE-533] Add Sentry Maven Skin

### DIFF
--- a/content/apt/skins/index.apt
+++ b/content/apt/skins/index.apt
@@ -68,6 +68,8 @@ Available Skins
 *-------------------------------------------------------------------+----------------+-----------------------+
 | {{{https://stevecrox.github.io/maven-site-bootstrap-skin//} <<<Bootstrap Site Skin>>>}} | {{{https://github.com/stevecrox/maven-site-bootstrap-skin} Stephen Crocker}} | Responsive Maven Bootstrap Skin which has toggleable elements implemented based on the boostrap reference layouts.
 *-------------------------------------------------------------------+----------------+-----------------------+
+| {{{https://sentrysoftware.org/sentry-maven-skin/} <<<Sentry Maven Skin>>>}} | {{{https://github.com/sentrysoftware/sentry-maven-skin} Sentry Software}} | Responsive skin, Bootstrap-based, with local search, light/dark colors switch, WEBP conversion, etc.
+*-------------------------------------------------------------------+----------------+-----------------------+
 
 * Instructions
 


### PR DESCRIPTION
Updated `content/apt/skins/index.apt` to list [Sentry Maven Skin](https://sentrysoftware.org/sentry-maven-skin/), a new skin for Maven Site with a bunch a nice features:

* Mobile friendly navigation
* Conversion of images to WEBP
* Zoomable images
* Local search with local index
* Dark color (automatic, manual toggle, persistent user preferences)
* Fontawesome icons replacing usual icon images
* Code syntax highlighting
* Pretty rendering for printing
* *etc.*