### PR TITLE
Fix multiline comment syntax

### DIFF
--- a/src/plantuml/buildExtensionClassRealm.puml
+++ b/src/plantuml/buildExtensionClassRealm.puml
@@ -1,4 +1,4 @@
-/*
+/'
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -15,7 +15,7 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.  
-*/
+'/
 @startuml
 !pragma layout smetana
 Platform o-- Bootstrap

--- a/src/plantuml/pluginClassRealm.puml
+++ b/src/plantuml/pluginClassRealm.puml
@@ -1,4 +1,4 @@
-/*
+/'
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -15,7 +15,7 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.  
-*/
+'/
 @startuml
 !pragma layout smetana
 Platform o-- Bootstrap


### PR DESCRIPTION
This patch corrects the syntax used to put the license string.
Tested using https://www.planttext.com/ and http://www.plantuml.com/plantuml/uml/