### PR TITLE
Set both maven.compiler.source and maven.compiler.target to 1.8 

### DIFF
--- a/content/apt/guides/getting-started/maven-in-five-minutes.apt
+++ b/content/apt/guides/getting-started/maven-in-five-minutes.apt
@@ -124,8 +124,8 @@ my-app
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Since Maven 3.9.6 does not support 1.7 compiler, the sample project cannot be built as is. 
![BuildFailure](https://github.com/apache/maven-site/assets/80066125/f2127afb-ed50-4fef-bda8-7228db132b49)
This is frustrating for an inexperienced user. 
The proposed fix was tested on Java 21.0.3, Win7 sp1+. 
P.S. Notice, the problem is not only with the docs.  The code issue is known but still unresolved:
https://issues.apache.org/jira/projects/MARCHETYPES/issues/MARCHETYPES-82?filter=allopenissues 
Even though the updated version was pushed to Maven Central Repository years ago: https://github.com/ywchang/maven-archetype-quickstart https://central.sonatype.com/artifact/com.github.ywchang/maven-archetype-quickstart 
In a meantime, the new user gets a build failure trying Maven for their first time.