### PR TITLE
fix: grammar mistake

### DIFF
--- a/content/apt/guides/plugin/guide-java-plugin-development.apt.vm
+++ b/content/apt/guides/plugin/guide-java-plugin-development.apt.vm
@@ -100,7 +100,7 @@ public class GreetingMojo extends AbstractMojo
   * The annotation "<<<@Mojo>>>" is required and control how and
     when the mojo is executed.
 
-  * The <<<execute>>> method can throw <<<org.apache.maven.plugin.MojoExecutionException>>> if an problem occurs.
+  * The <<<execute>>> method can throw <<<org.apache.maven.plugin.MojoExecutionException>>> if a problem occurs.
     Throwing this exception causes a <<<BUILD FAILURE>>> message to be displayed.
 
   * The <<<getLog>>> method (defined in <<<AbstractMojo>>>) returns a


### PR DESCRIPTION
`Problem` does not start with a vowel sound and requires `a` as an indefinite article.

I stumbled upon this simple mistake while reading the docs and it somehow kept my attention. :see_no_evil: 