### PR TITLE
Escape project property to prevent evaluation

### DIFF
--- a/content/apt/guides/plugin/guide-java-report-plugin-development.apt.vm
+++ b/content/apt/guides/plugin/guide-java-report-plugin-development.apt.vm
@@ -295,7 +295,7 @@ public class SimpleReport extends AbstractMavenReport {
     /**
      * Practical reference to the Maven project
      */
-    @Parameter(defaultValue = "${project}", readonly = true)
+    @Parameter(defaultValue = "\${project}", readonly = true)
     private MavenProject project;
 
     @Override


### PR DESCRIPTION
Currently https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html:

![image](https://github.com/apache/maven-site/assets/11896137/8d136fcd-a0da-4cea-b0d3-bcafb0689571)

With this change I'm getting locally:

![image](https://github.com/apache/maven-site/assets/11896137/71e87ece-11c2-4f40-8c9a-5489207f5e4e)

