### PR TITLE
Escape properties to prevent evaluation

### DIFF
--- a/content/apt/pom.apt.vm
+++ b/content/apt/pom.apt.vm
@@ -832,7 +832,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 -------------------------------
 <build>
   <defaultGoal>install</defaultGoal>
-  <directory>${project.basedir}/target</directory>
+  <directory>\${project.basedir}/target</directory>
   <finalName>${artifactId}-${version}</finalName>
   <filters>
     <filter>filters/filter1.properties</filter>
@@ -888,7 +888,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
       <resource>
         <targetPath>META-INF/plexus</targetPath>
         <filtering>false</filtering>
-        <directory>${project.basedir}/src/main/plexus</directory>
+        <directory>\${project.basedir}/src/main/plexus</directory>
         <includes>
           <include>configuration.xml</include>
         </includes>
@@ -1134,7 +1134,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
             <inherited>false</inherited>
             <configuration>
               <tasks>
-                <echo>Build Dir: ${project.build.directory}</echo>
+                <echo>Build Dir: \${project.build.directory}</echo>
               </tasks>
             </configuration>
           </execution>
@@ -1249,11 +1249,11 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   ...
   <build>
-    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
-    <scriptSourceDirectory>${project.basedir}/src/main/scripts</scriptSourceDirectory>
-    <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
-    <outputDirectory>${project.basedir}/target/classes</outputDirectory>
-    <testOutputDirectory>${project.basedir}/target/test-classes</testOutputDirectory>
+    <sourceDirectory>\${project.basedir}/src/main/java</sourceDirectory>
+    <scriptSourceDirectory>\${project.basedir}/src/main/scripts</scriptSourceDirectory>
+    <testSourceDirectory>\${project.basedir}/src/test/java</testSourceDirectory>
+    <outputDirectory>\${project.basedir}/target/classes</outputDirectory>
+    <testOutputDirectory>\${project.basedir}/target/test-classes</testOutputDirectory>
     ...
   </build>
 </project>


### PR DESCRIPTION
- Similar to #543

Currently https://maven.apache.org/pom.html:
![b1](https://github.com/apache/maven-site/assets/11896137/7f82a054-7965-4447-a492-1bacd0e6ddb5)
![b2](https://github.com/apache/maven-site/assets/11896137/100948b6-88bb-4ca7-bf3d-85d102b71e45)
![b3](https://github.com/apache/maven-site/assets/11896137/d8e20b39-1a97-4cf5-a489-b72a9d134a0f)
![b4](https://github.com/apache/maven-site/assets/11896137/5a43c2f6-71ed-4605-b022-6034ca0c373a)

With this change I'm getting locally:
![a1](https://github.com/apache/maven-site/assets/11896137/ba8d3e32-00ae-4c8a-863a-ca01a4671da4)
![a2](https://github.com/apache/maven-site/assets/11896137/c977f7e8-ad4b-4330-983c-eff9c688c828)
![a3](https://github.com/apache/maven-site/assets/11896137/b5ea317f-2764-4b54-b78a-b3b48ae3d7b6)
![a4](https://github.com/apache/maven-site/assets/11896137/76ffa21d-5369-4b4c-af9f-308624b66ca9)
