### PR TITLE
Correct the Javadoc links in maven-3-lifecycle-extensions

### DIFF
--- a/content/apt/examples/maven-3-lifecycle-extensions.apt.vm
+++ b/content/apt/examples/maven-3-lifecycle-extensions.apt.vm
@@ -32,11 +32,11 @@ Example: Using Maven 3 lifecycle extension
 
   You can extend multiple classes depending on your needs:
 
-  * {{{/ref/current/maven-core/apidocs/index.html?org/apache/maven/execution/AbstractExecutionListener.html}<<<org.apache.maven.execution.AbstractExecutionListener>>>}},
+  * {{{/ref/current/maven-core/apidocs/org/apache/maven/execution/AbstractExecutionListener.html}<<<org.apache.maven.execution.AbstractExecutionListener>>>}},
 
-  * {{{/ref/current/maven-core/apidocs/index.html?org/apache/maven/AbstractMavenLifecycleParticipant.html}<<<org.apache.maven.AbstractMavenLifecycleParticipant>>>}},
+  * {{{/ref/current/maven-core/apidocs/org/apache/maven/AbstractMavenLifecycleParticipant.html}<<<org.apache.maven.AbstractMavenLifecycleParticipant>>>}},
 
-  * {{{/ref/current/maven-core/apidocs/index.html?org/apache/maven/eventspy/AbstractEventSpy.html}<<<org.apache.maven.eventspy.AbstractEventSpy>>>}}
+  * {{{/ref/current/maven-core/apidocs/org/apache/maven/eventspy/AbstractEventSpy.html}<<<org.apache.maven.eventspy.AbstractEventSpy>>>}}
 
   []
 


### PR DESCRIPTION
Looks like these were older style javadoc links, which now show the non-frame root page.
Updating the links so they point directly to the correct extension classes
