### PR TITLE
update POM Reference page's TOC bad anchor

### DIFF
--- a/content/apt/pom.apt.vm
+++ b/content/apt/pom.apt.vm
@@ -1233,7 +1233,7 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
 +------------------------------------------+
 
 
-** The {Build Element} Set
+** {The Build Element Set}
 
   The <<<Build>>> type in the XSD denotes those elements that are available only for the "project build". Despite
   the number of extra elements (six), there are really only two groups of elements that project build contains


### PR DESCRIPTION
hello, i've found the main documentation site of Maven has a bad anchor reference, the page is `https://maven.apache.org/pom.html`, and the bad anchor is `https://maven.apache.org/pom.html#The_Build_Element_Set`.

this is the page:
![image](https://github.com/user-attachments/assets/ef9a19b5-4583-4fae-82f8-6fe331dac268)

The later one can't jump to its target section, i tried to fix it.

