### PR TITLE
Enable GitHub issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,8 +31,12 @@ github:
     - MASSEMBLY
     - FELIX
     - MRELEASE
+  del_branch_on_merge: true
+  features:
+    issues: true
+
 notifications:
   commits: commits@maven.apache.org
   issues: issues@maven.apache.org
   pullrequests: issues@maven.apache.org
-  jira_options: link label comment
+  jira_options: link label

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,0 +1,45 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report.     
+
+        Simple fixes in single PRs do not require issues. 
+
+  - type: textarea
+    id: massage
+    attributes:
+      label: Bug description
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Maven site URL where bug exists
+      placeholder: https://maven.apache.org/...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/IMPROVEMENT.yml
+++ b/.github/ISSUE_TEMPLATE/IMPROVEMENT.yml
@@ -1,0 +1,35 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+name: Improvement Proposal
+description: File a a proposal for improvement
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this improvement proposal.
+
+  - type: textarea
+    id: massage
+    attributes:
+      label: Improvement proposal
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,30 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: false
+
+contact_links:
+
+  - name: Project Mailing Lists
+    url: https://maven.apache.org/mailing-lists.html
+    about: Please ask a questions or discuss here
+
+  - name: Old JIRA Issues
+    url: https://issues.apache.org/jira/projects/MNGSITE
+    about: Please search old JIRA issues

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 
 # Maven Site
 
-[![ASF Jira](https://img.shields.io/endpoint?url=https%3A%2F%2Fmaven.apache.org%2Fbadges%2Fasf_jira-MNGSITE.json)][jira]
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Jenkins Status](https://img.shields.io/jenkins/s/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-site/job/master.svg)][build]
 
@@ -38,14 +37,12 @@ Additional Resources
 --------------------
 
 + [Contributing patches](https://maven.apache.org/guides/development/guide-maven-development.html#Creating_and_submitting_a_patch)
-+ [Apache Maven Site JIRA project page][jira]
 + [Contributor License Agreement][cla]
-+ [General GitHub documentation](https://help.github.com/)
-+ [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
++ [General GitHub documentation](https://docs.github.com)
++ [GitHub pull request documentation](https://docs.github.com/pull-requests)
 + [Apache Maven Twitter Account](https://twitter.com/ASFMavenProject)
 + [Slack channel in ASF Workspace](https://infra.apache.org/slack.html)
 
-[jira]: https://issues.apache.org/jira/projects/MNGSITE/
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 [ml-list]: https://maven.apache.org/mailing-lists.html
 [cla]: https://www.apache.org/licenses/#clas

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
   </scm>
 
   <issueManagement>
-    <system>jira</system>
-    <url>https://issues.apache.org/jira/browse/MNGSITE</url>
+    <system>GitHub</system>
+    <url>https://github.com/apache/maven-site/issues</url>
   </issueManagement>
   <distributionManagement>
     <site>


### PR DESCRIPTION
I hope that we not need an issues migration for this project - it is simply current state of site.

We have 66 issues opened now:
https://issues.apache.org/jira/projects/MNGSITE

After it we can create a pined issue with information and link to JIRA

Next steps after merge:
 - block for creating new issues in JIRA - existing issues should be possible to comments, closing and so on
