### PR TITLE
Fix link to "Introduction to repositories" page on guides-index

### DIFF
--- a/content/apt/guides/index.apt.vm
+++ b/content/apt/guides/index.apt.vm
@@ -79,7 +79,7 @@ Documentation
 
  * {{{./mini/guide-relocation.html}Relocation of Artifacts}}
 
-** {{{/introduction/introduction-to-repositories.html}Repositories}}
+** {{{./introduction/introduction-to-repositories.html}Repositories}}
 
  * {{{./mini/guide-3rd-party-jars-local.html}Installing 3rd party JARs to Local Repository}}
 


### PR DESCRIPTION
On the guides/index.html site, the link to the "introduction to repositories" page is broken.