### PR TITLE
[MNGSITE-526] Fix URL of 4.1.0 XSD

### DIFF
--- a/content/apt/guides/introduction/introduction-to-dependency-mechanism.apt
+++ b/content/apt/guides/introduction/introduction-to-dependency-mechanism.apt
@@ -824,7 +824,7 @@ Introduction to the Dependency Mechanism
 +----+
 
 <project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
   <parent>
     <groupId>com.test</groupId>
     <version>1.0.0</version>


### PR DESCRIPTION
Was the only reference I found.
If this URL is opened it redirects to current version (RC2 as of today).