### PR TITLE
MNGSITE-534 Mention Maven Daemon

### DIFF
--- a/content/markdown/tools/index.md
+++ b/content/markdown/tools/index.md
@@ -1,0 +1,35 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<head>
+   <title>Maven Tools</title>
+</head>
+
+# Maven Tools
+
+The pages in this section will give information about additional Maven tools, which can help to improve your build.
+
+## Supported By The Maven Project
+
+| Name         | Description                                                                                       | Link        |
+|:-------------|:--------------------------------------------------------------------------------------------------|:------------|
+| Maven Daemon | This project aims at providing faster Maven builds using techniques known from Gradle and Takari. | [Github][1] |
+
+[1]: https://github.com/apache/maven-mvnd
+

--- a/content/site.xml
+++ b/content/site.xml
@@ -59,6 +59,7 @@ under the License.
     <menu name="Documentation">
       <item name="Maven Plugins" href="/plugins/index.html"/>
       <item name="Maven Extensions" href="/extensions/index.html"/>
+      <item name="Maven Tools" href="/tools/index.html"/>
       <item name="Index (category)" href="/guides/index.html"/>
 
       <item name="User Centre" href="/users/index.html" collapse="true">
@@ -166,7 +167,7 @@ under the License.
         <item name="Code Style and Conventions" href="/developers/conventions/code.html"/>
         <item name="JIRA Convention" href="/developers/conventions/jira.html"/>
         <item name="Git Convention" href="/developers/conventions/git.html"/>
-        <item name="GitHub Convention" href="/developers/conventions/github.html" />
+        <item name="GitHub Convention" href="/developers/conventions/github.html"/>
         <item name="Developing Maven" href="/guides/development/guide-maven-development.html" collapse="true">
           <item name="Building Maven" href="/guides/development/guide-building-maven.html"/>
           <item name="Testing Development Plugins" href="/guides/development/guide-testing-development-plugins.html"/>


### PR DESCRIPTION
This PR adds a new section "Maven Tools" to the site's navigation to create a place about tools aside Maven itself, similar to the plugin page. Initially only the Maven Daemon is listed on the index page, but in the future more tools can be added, e.g. Maven Shell, Maven Encrypt etc.