### PR TITLE
[MNGSITE-446] Properties file gets deleted by default.

### DIFF
--- a/content/apt/guides/mini/guide-releasing.apt
+++ b/content/apt/guides/mini/guide-releasing.apt
@@ -235,12 +235,11 @@ checkpoint.prepared-release=OK
 checkpoint.check-in-development-version=OK
 -----
 
-  The <release.properties> file is created while preparing the release. The <release.properties> file can be given to any developer within the team and
-  by simply executing the <<<release:perform>>> goal can create and deploy a new instance of the project artifact time and again.
+  The <release.properties> file is created while preparing the release.
   By default the file gets deleted after a successful release.
   
-  During the execution of the <<<release:perform>>> goal the entire maven build lifecycle is executed on the project.  
-  The tagged project source code is extracted, compiled, tested, documented and deployed.  An instance of the release artifact is deployed 
+  During the execution of the <<<release:perform>>> goal, the entire maven build lifecycle is executed on the project.
+  The tagged project source code is extracted, compiled, tested, documented, and deployed.  An instance of the release artifact is deployed
   to the machine's local repository.  An another instance of the release can be deployed to a remote repository by configuring the 
   <distributionManagement> element within the <pom.xml> file.
 

--- a/content/apt/guides/mini/guide-releasing.apt
+++ b/content/apt/guides/mini/guide-releasing.apt
@@ -235,9 +235,9 @@ checkpoint.prepared-release=OK
 checkpoint.check-in-development-version=OK
 -----
 
-  The <release.properties> file is created while preparing the release.  After performing the release the file remains within the project root 
-  directory until the maven user deletes it.  The <release.properties> file can be given to any developer within the team and 
-  by simply excuting the <<<release:perform>>> goal can create and deploy a new instance of the project artifact time and again.
+  The <release.properties> file is created while preparing the release. The <release.properties> file can be given to any developer within the team and
+  by simply executing the <<<release:perform>>> goal can create and deploy a new instance of the project artifact time and again.
+  By default the file gets deleted after a successful release.
   
   During the execution of the <<<release:perform>>> goal the entire maven build lifecycle is executed on the project.  
   The tagged project source code is extracted, compiled, tested, documented and deployed.  An instance of the release artifact is deployed 

--- a/content/apt/guides/mini/guide-releasing.apt
+++ b/content/apt/guides/mini/guide-releasing.apt
@@ -238,7 +238,7 @@ checkpoint.check-in-development-version=OK
   The <release.properties> file is created while preparing the release.
   By default the file gets deleted after a successful release.
   
-  During the execution of the <<<release:perform>>> goal, the entire maven build lifecycle is executed on the project.
+  During the execution of the <<<release:perform>>> goal, Maven executes the project's entire build lifecycle.
   The tagged project source code is extracted, compiled, tested, documented, and deployed.  An instance of the release artifact is deployed
   to the machine's local repository.  An another instance of the release can be deployed to a remote repository by configuring the 
   <distributionManagement> element within the <pom.xml> file.


### PR DESCRIPTION
According to docs of the plugin itself as well of my understanding of the plugin code myself, the clean phase is executed by default after a successful release by default (DefaultReleaseManager).

So I updated this in the docs on site.

Closes #MNGSITE-446.