### PR TITLE
Add a link to Github convetions on the developers index page

### DIFF
--- a/content/apt/developers/index.apt
+++ b/content/apt/developers/index.apt
@@ -85,6 +85,8 @@ Maven Developer Centre
 
   * {{{./conventions/git.html}Maven Git Convention}}
 
+  * {{{./conventions/github.html}Maven GitHub Convention}}
+
   []
 
  <<Note>>: If you cannot find your answers here, feel free to ask the {{{mailto:dev@maven.apache.org}Maven Developer List}}.


### PR DESCRIPTION
The developers index page (https://maven.apache.org/developers/index.html) does not contain the GitHub convention link the main menu has. This PR aligns both.