### PR TITLE
Fix link and add "PMC only" label on project-roles page

### DIFF
--- a/content/markdown/project-roles.md
+++ b/content/markdown/project-roles.md
@@ -210,8 +210,7 @@ The Project Management Committee has the following responsibilities:
 * Vote on release artifacts;
 * Ensure [Developers Conventions][5] are followed, or updated/improved if necessary.
 * Know and respect the goals and processes of the community and help educate
-  newer members about them and their
-  [internal details][https://svn.apache.org/repos/private/pmc/maven/project-conventions.txt].
+  newer members about them and their [internal details (PMC members access only)][13].
 
 #### Standards for Community Commitment
 
@@ -281,7 +280,7 @@ Finally, where a fork is hosted outside of Apache hardware, there is less
 traceability of the code provenance. For example, Git commits can be squashed
 and history re-written to mask or otherwise hide the source of contributions.
 This does not mean that code coming from an external fork inherently has
-such issues. Instead it means that the requirements for review and verification
+such issues. Instead, it means that the requirements for review and verification
 of provenance grow exponentially when dealing with large sets of changes
 originating from a long running fork hosted outside of Apache foundation
 source control. Anybody maintaining a long running fork should be aware


### PR DESCRIPTION
closes #658