### PR TITLE
Add info about EOL to release history.

### DIFF
--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -131,7 +131,7 @@ $esc.h$esc.h Maven 3.8.x+
 
 $esc.h$esc.h Maven 3.6.x and before
 
-<p>Maven before 3.6.3 has now reached its end of life and is no longer supported in any way.
+<p>Maven 3.6.3 and before has now reached its end of life and is no longer supported in any way.
 New plugin releases will require Maven 3.6.3 or later.
 The following information is made available for reference.</p>
 

--- a/content/markdown/docs/history.md.vm
+++ b/content/markdown/docs/history.md.vm
@@ -60,10 +60,15 @@ The last release is ${current39xVersion}, the Apache Maven team project will mai
 - ${current39xVersion}
 - ${current38xVersion}
 
+Older versions have reached their end of life and are no longer supported in any way.
+This means the Maven team will not provide any bug or security fixes or add new features.
+Note: Maven does not differentiate between "end of life" (EOL) and "end of support" (EOS), but only uses the term "end of life".
+
 Currently, plugins provide Maven API compatibility down to **3.2.5**. 
 New plugin releases will require Maven **3.6.3** or later. See [Maven Plugins Compatibility Plan](/developers/compatibility-plan.html) for more details.
 
 Date format is YYYY-MM-DD
+
 
 $esc.h$esc.h Maven 4.0+
 <table>
@@ -126,7 +131,7 @@ $esc.h$esc.h Maven 3.8.x+
 
 $esc.h$esc.h Maven 3.6.x and before
 
-<p>Maven before 3.6.3 has now reached its end of life.
+<p>Maven before 3.6.3 has now reached its end of life and is no longer supported in any way.
 New plugin releases will require Maven 3.6.3 or later.
 The following information is made available for reference.</p>
 


### PR DESCRIPTION
Based on the slack discussion, I added a small information what does EOL means for Maven and that there is no difference between EOL and EOS for us.