### PR TITLE
Downloads instead of Download

### DIFF
--- a/content/site.xml
+++ b/content/site.xml
@@ -45,7 +45,7 @@ under the License.
       <item name="What is Maven?" href="/what-is-maven.html"/>
       <item name="Features" href="/maven-features.html"/>
       <item name="Installation" href="/install.html" />
-      <item name="Download" href="/download.html"/>
+      <item name="Downloads" href="/download.html"/>
       <item name="Use" href="/users/index.html" collapse="true">
         <item name="Run" href="/run.html"/>
         <item name="Configure" href="/configure.html"/>


### PR DESCRIPTION
Minor change: It should say Downloads instead of Download in site navigation. 

There is more than one thing to download: different files for the latest Apache Maven version, Apache Maven Daemon (mvnd) and other previous stable releases.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

