### PR TITLE
[MNGSITE-468] Update namespace of archetype-descriptor

### DIFF
--- a/content/apt/guides/mini/guide-creating-archetypes.apt
+++ b/content/apt/guides/mini/guide-creating-archetypes.apt
@@ -71,7 +71,7 @@ Guide to Creating Archetypes
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>3.1.1</version>
+        <version>3.4.0</version>
       </extension>
     </extensions>
   </build>
@@ -93,8 +93,8 @@ Guide to Creating Archetypes
 +----+
 
 <archetype-descriptor
-        xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd"
+        xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.2.0 https://maven.apache.org/xsd/archetype-descriptor-1.2.0.xsd"
         name="quickstart">
     <fileSets>
         <fileSet filtered="true" packaged="true">


### PR DESCRIPTION
As defined in https://github.com/apache/maven-site/blob/master/content/resources/xsd/archetype-descriptor-1.2.0.xsd