### PR TITLE
Remove or replace broken links to codehaus

### DIFF
--- a/content/apt/archives/maven-2.x/maven-2.1-architectural-goals.apt
+++ b/content/apt/archives/maven-2.x/maven-2.1-architectural-goals.apt
@@ -66,7 +66,7 @@ Maven 2.1
 
 * Plugin API
 
-** Shading of plexus-utils causing a ClassCastException on plugin.getConfiguration() ([MNG-3012|http://jira.codehaus.org/browse/MNG-3012])
+** Shading of plexus-utils causing a ClassCastException on plugin.getConfiguration() ([MNG-3012|https://issues.apache.org/jira/browse/MNG-3012])
 
  The fact that plexus-utils is hidden from plugins in the newer releases of Maven means that plugin.getConfiguration() from maven-model can cause a ClassCastException, if used from within a mojo. The plan to fix this is basically just to import Xpp3Dom from the shaded plexus-utils version in maven-core within the plugin's classrealm. This should allow us to share the same instance of that class (only, shouldn't really affect other p-u classes) and preserve backward compatibility for existing plugin releases.
 
@@ -178,7 +178,7 @@ jason: so when you and benjamin went through the tests you have "integration-tes
 
 ** Custom Components
 
-    As discussed in [Substituting of Custom Components|http://docs.codehaus.org/display/MAVEN/Substitution+of+Custom+Maven+Components] we now have two ways
+    As discussed in "Substituting of Custom Components", we now have two ways
     to insert new components into the system.
 
     Using a directory and specifying it in the Classworlds configuration. Tycho simply has a special set of components that load first before the standard maven components and they override
@@ -252,14 +252,14 @@ load ${maven.home}/lib/*.jar
 
 ** Core Refactorings
 
-    * Project Builder ([architecture|http://docs.codehaus.org/display/MAVENUSER/Project+Builder])
+    * Project Builder architecture
     ** Maven shared model work: a new way of reading in the models for Maven that is not format dependent in any way i.e. XML, text, YAML, scripts, whatever.
     ** Pluggable model readers: this could leverage different implementations provided by the shared model work, but we still need a way to detect the type and version
        of the model that we want to consume
     ** A new terse format that uses attributes
     ** Automatic parent versioning
     ** New interpolation component (plexus-interpolation)
-    ** Dynamic build sections ([MNG-3530|http://jira.codehaus.org/browse/MNG-3530])
+    ** Dynamic build sections ([MNG-3530|http://issues.apache.org/browse/MNG-3530])
     ** Mixin support -- allowing a paramterizable template which can be imported with one line.
 
     * Remove the use of separate plugin repositories. We only need to pull resources from one repository. We started doing this but I've had a couple

--- a/content/apt/docs/2.0.10/release-notes.apt.vm
+++ b/content/apt/docs/2.0.10/release-notes.apt.vm
@@ -46,10 +46,6 @@ Maven 2.0.10
 
     * the maven-user mailing list: {{http://maven.apache.org/mailing-lists.html}}
 
-  For news and information, see:
-
-    * Maven Dashboard: {{http://docs.codehaus.org/display/MAVEN/Home}}
-
 * Issue Summary
   
   {{https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12330157}}

--- a/content/apt/docs/2.0.11/release-notes.apt.vm
+++ b/content/apt/docs/2.0.11/release-notes.apt.vm
@@ -44,10 +44,6 @@ Maven 2.0.11
 
     * the maven-user mailing list: {{https://maven.apache.org/mailing-lists.html}}
 
-  For news and information, see:
-
-    * Maven Dashboard: {{http://docs.codehaus.org/display/MAVEN/Home}}
-
 * Issue Summary
   
   {{https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12330158}}

--- a/content/apt/guides/development/guide-plugin-documentation.apt.vm
+++ b/content/apt/guides/development/guide-plugin-documentation.apt.vm
@@ -280,8 +280,7 @@ Plugin Name
 
   General instructions on how to use the Plugin Name can be found on the {{{usage.html}usage page}}. Some more
   specific use cases are described in the examples given below. Last but not least, users occasionally contribute
-  additional examples, tips or errata to the
-  {{{http://docs.codehaus.org/display/MAVENUSER/Plugin+Name}plugin's wiki page}}.
+  additional examples, tips or errata to the plugin's wiki page.
 
   In case you still have questions regarding the plugin's usage, please have a look at the {{{faq.html}FAQ}} and feel
   free to contact the {{{mailing-lists.html}user mailing list}}. The posts to the mailing list are archived and could

--- a/content/apt/plugin-developers/plugin-testing.apt
+++ b/content/apt/plugin-developers/plugin-testing.apt
@@ -32,7 +32,7 @@ Introduction
  Currently, Maven only supports unit testing out of the box. This document is intended to help Maven Developers
  test plugins with unit tests, integration tests, and functional tests.
 
-~~  <<Note: There are a lot of different ways to test a Maven plugin.>>  For a review of different strategies and tools, please refer to {{{http://docs.codehaus.org/display/MAVENUSER/Review+of+Plugin+Testing+Strategies}Review of Plugin Testing Strategies}}
+~~  <<Note: There are a lot of different ways to test a Maven plugin.>>  For a review of different strategies and tools, please refer to "Review of Plugin Testing Strategies."
 
 Testing Styles: Unit Testing vs. Functional/Integration Testing
 

--- a/content/apt/pom.apt.vm
+++ b/content/apt/pom.apt.vm
@@ -1483,8 +1483,8 @@ Display parameters as parsed by Maven (in canonical form and as a list of tokens
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   ...
   <organization>
-    <name>Codehaus Mojo</name>
-    <url>http://mojo.codehaus.org</url>
+    <name>Mojohaus</name>
+    <url>http://www.mojohaushaus.org</url>
   </organization>
 </project>
 +-------------------------+
@@ -1958,7 +1958,7 @@ scm:cvs:pserver:127.0.0.1:/cvs/root:my-project
   ...
   <distributionManagement>
     ...
-    <downloadUrl>http://mojo.codehaus.org/my-project/download.html</downloadUrl>
+    <downloadUrl>http://www.mojohaus.org/my-project/download.html</downloadUrl>
   </distributionManagement>
   ...
 </project>

--- a/content/markdown/docs/3.2.2/release-notes.md
+++ b/content/markdown/docs/3.2.2/release-notes.md
@@ -70,7 +70,7 @@ Note this requires Maven 3.2.2 so if you use this new feature it is encouraged y
 
 ### Requiring multiple profile activation conditions to be true does not work ([MNG-4565][MNG-4565])
 
-Multiple profile activation conditions are now ANDed instead of ORed. We believe this is the correct behaviour as prior to this change activating a profile where multiple conditions are required was impossible. If you do need OR behaviour then you can create multiple profiles with a single condition. Profiles certainly have limitations and can likely be addressed without requiring conditional syntax in the POM by using a single custom activator that employs an expression language like [MVEL][mvel].
+Multiple profile activation conditions are now ANDed instead of ORed. We believe this is the correct behaviour as prior to this change activating a profile where multiple conditions are required was impossible. If you do need OR behaviour then you can create multiple profiles with a single condition. Profiles certainly have limitations and can likely be addressed without requiring conditional syntax in the POM by using a single custom activator that employs an expression language like MVEL.
 
 ### Support resolution of Import Scope POMs from Repo that contains a ${parameter} ([MNG-5639][MNG-5639])
 
@@ -129,5 +129,4 @@ See [complete release notes for all versions][5]
 [MNG-5452]: https://issues.apache.org/jira/browse/MNG-5452
 [MNG-5639]: https://issues.apache.org/jira/browse/MNG-5639
 [MNG-5647]: https://issues.apache.org/jira/browse/MNG-5647
-[mvel]: http://mvel.codehaus.org
 

--- a/content/markdown/faq-unoffical.md
+++ b/content/markdown/faq-unoffical.md
@@ -127,7 +127,7 @@ bug. Tickets may also be issued for feature enhancement requests, and other task
 
 ### How do I include/exclude the other modules in the navigation menu in the parent site?
 
-[MNG-661](http://jira.codehaus.org/browse/MNG-661), provides a simple patch which provides parent and module links using
+MNG-661 provides a simple patch which provides parent and module links using
 the project URLs which as you correctly point out only work when the site is deployed.
 
 -- ## Errors, Dependencies, Plugins
@@ -171,11 +171,6 @@ This command will install the file in your local repository along with your cust
 _Plugins & Lifecycle_
 
 ## General
-
-### What is the difference between Maven and Ivy?
-
-For a comparison of Maven's features vs Ivy's you can refer to
-our [feature comparison](http://docs.codehaus.org/display/MAVEN/Feature+Comparisons)
 
 ### How do I get a plugin's dependencies from a Mojo?
 
@@ -511,7 +506,7 @@ You can integrate your static pages in this several steps,
 maven-war-plugin 2.0-beta-3 and later supports merging of wars. Just reference the common WAR project from another WAR
 project as a dependency of `<type>war</type>` and it will automatically be merged.
 
-See [http://jira.codehaus.org/browse/MWAR-8)
+See [https://issues.apache.org/jira/browse/MWAR-8)
 
 _Inheritance and Interpolation_
 
@@ -881,13 +876,12 @@ _Plugins and Lifecycle, Sites & Reporting, Integration tests_
 
 ### The snapshot version of the plugin is not updated in the snapshot repo, What should I do to update my copy of the plugin?
 
-If the plugin in the snapshot repo ([http://snapshots.maven.codehaus.org/maven2]) is not yet updated. The only way to
+If the plugin in the snapshot repo is not yet updated. The only way to
 update it is to check out the source from SVN and build it.
 
 ### Is there a way to get Maven to report the number of compile errors found?
 
-Currently, this type of summary information is not built into the compiler plugin, but it would be possible to add. If
-this feature is important to you, add your vote to [MNG-1854](http://jira.codehaus.org/browse/MNG-1854).
+Currently, this type of summary information is not built into the compiler plugin, but it would be possible to add.
 
 _Sites & Reporting_
 
@@ -1422,11 +1416,8 @@ JDKs).
 
 ### How to remove the artifact in the local repository?
 
-As of now, There is no tool for it. You have to manually delete them in your local repository. However,
-there is already some discussion about this. Please refer to these links for more info.
-
-[http://jira.codehaus.org/browse/MNG-233]
-[http://jira.codehaus.org/browse/MRELEASE-68]
+As of now, there is no tool for it. You have to manually delete them in your local repository. However,
+there is already some discussion about this.
 
 ### How to make a war artifact as a dependency?
 
@@ -1471,7 +1462,7 @@ meaning it is still in the state of development. There are some ways the append 
 
 ### How to run a java program from Maven?
 
-You may use the [exec-maven-plugin](https://mojo.codehaus.org/exec-maven-plugin/usage.html) for this.
+You may use the [exec-maven-plugin](https://www.mojohaus.org/exec-maven-plugin/) for this.
 
 ### How can I make the war plugin produces an exploded war instead of .war file?
 
@@ -1737,7 +1728,7 @@ Since the two don't match, XDoclet assumes that there is a serious problem with 
 How will the plugin be licensed? Is it intended to just be a binary distribution or will the source be available? Where
 will be the documentation be? How will people find out about it?
 I think your choice is probably influenced by these questions. One option, of course, is to propose it to
-mojo.codehaus.org if you want to and can share the code.
+www.mojohaus.org if you want to and can share the code.
 
 ### How do I access downloaded sources in eclipse?
 
@@ -1857,7 +1848,7 @@ For example, for Maven snapshots as stated below, you could use :
 <repositories>
   <repository>
     <id>maven-snapshots</id>
-    <url>http://snapshots.maven.codehaus.org/</url>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
   </repository>
 </repositories>
 ```
@@ -1869,7 +1860,7 @@ or, for plugins :
 <pluginRepositories>
   <pluginRepository>
     <id>maven-snapshots</id>
-    <url>http://snapshots.maven.codehaus.org/</url>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
   </pluginRepository>
 </pluginRepositories>
 ```

--- a/content/markdown/settings.md
+++ b/content/markdown/settings.md
@@ -395,8 +395,8 @@ artifact.
       ...
       <repositories>
         <repository>
-          <id>codehausSnapshots</id>
-          <name>Codehaus Snapshots</name>
+          <id>Snapshots</id>
+          <name>Snapshots</name>
           <releases>
             <enabled>false</enabled>
             <updatePolicy>always</updatePolicy>
@@ -407,7 +407,7 @@ artifact.
             <updatePolicy>never</updatePolicy>
             <checksumPolicy>fail</checksumPolicy>
           </snapshots>
-          <url>http://snapshots.maven.codehaus.org/maven2</url>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
           <layout>default</layout>
         </repository>
       </repositories>


### PR DESCRIPTION
I added a new URL if I could find one, but many of these links appear to be completely gone and mever migrated elsewhere