### PR TITLE
[MNGSITE-500] Notice IDE plugins for palantir on code convention page

### DIFF
--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -36,7 +36,7 @@ Maven Code Style And Code Conventions
 
  Optionally, you can still import the code style formatter for your IDE from
  {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
- To format Java code, there are plugins for many IDE on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
+ To format Java code, there are plugins for many IDEs on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 
 %{toc|section=1|fromDepth=2|toDepth=3}
 

--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -60,8 +60,8 @@ Maven Code Style And Code Conventions
 ** Java Code Style
 
  Maven adopts the {{{https://github.com/palantir/palantir-java-format}palantir Java format}}.
- As the code formatting of Java files is automatically enforced or even applied with {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
- using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}, developers usually don't need to care and the following sections are just for informational purposes.
+ The code formatting of Java files is automatically enforced by {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
+ using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}. You can automatically format code using the plugin too. To do so run the command <mvn spotless:apply>.
 
  Optionally, you can still import the code style formatter for your IDE from
  {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.

--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -61,9 +61,9 @@ Maven Code Style And Code Conventions
 
  Maven adopts the {{{https://github.com/palantir/palantir-java-format}palantir Java format}}.
  The code formatting of Java files is automatically enforced by {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
- using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}. You can automatically format code using the plugin too. To do so run the command <mvn spotless:apply>.
+ using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}. You can format the code by running the command <mvn spotless:apply>.
 
- Optionally, you can still import the code style formatter for your IDE from
+ You can import the code style formatter for your IDE from
  {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
  To format Java code, there are plugins for many IDEs on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 

--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -31,12 +31,6 @@ Maven Code Style And Code Conventions
  This document describes the rules for how the sources should be formatted
  in order to improve consistency, readability and maintainability.
 
- As the formatting is automatically enforced or even applied with {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
- using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}, developers usually don't need to care and the following sections are just for informational purposes.
-
- Optionally, you can still import the code style formatter for your IDE from
- {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
- To format Java code, there are plugins for many IDEs on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 
 %{toc|section=1|fromDepth=2|toDepth=3}
 
@@ -66,6 +60,12 @@ Maven Code Style And Code Conventions
 ** Java Code Style
 
  Maven adopts the {{{https://github.com/palantir/palantir-java-format}palantir Java format}}.
+ As the code formatting of Java files is automatically enforced or even applied with {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
+ using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}, developers usually don't need to care and the following sections are just for informational purposes.
+
+ Optionally, you can still import the code style formatter for your IDE from
+ {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
+ To format Java code, there are plugins for many IDEs on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 
 ** Java Code Convention
 

--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -60,10 +60,10 @@ Maven Code Style And Code Conventions
 ** Java Code Style
 
  Maven adopts the {{{https://github.com/palantir/palantir-java-format}palantir Java format}}.
- The code formatting of Java files is automatically enforced by {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
+ The code formatting of Java files is enforced by the {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
  using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}. You can format the code by running the command <mvn spotless:apply>.
 
- You can import the code style formatter for your IDE from
+ You can download the code style formatter for your IDE from
  {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
  To format Java code, there are plugins for many IDEs on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 

--- a/content/apt/developers/conventions/code.apt
+++ b/content/apt/developers/conventions/code.apt
@@ -32,10 +32,11 @@ Maven Code Style And Code Conventions
  in order to improve consistency, readability and maintainability.
 
  As the formatting is automatically enforced or even applied with {{{https://github.com/diffplug/spotless/tree/main/plugin-maven}spotless-maven-plugin}} for all projects
- using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}} developers usually don't need to care and the following sections are just for informational purposes.
+ using {{{/pom/maven/index.html}Maven Project Parent POM 38 or newer}}, developers usually don't need to care and the following sections are just for informational purposes.
 
- Optionally you can still import the code style formatter for your IDE from
- {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}
+ Optionally, you can still import the code style formatter for your IDE from
+ {{{https://gitbox.apache.org/repos/asf?p=maven-shared-resources.git;a=tree;f=src/main/resources/config;hb=HEAD}shared-resources}}.
+ To format Java code, there are plugins for many IDE on the {{{https://github.com/palantir/palantir-java-format}palantir Java format GitHub page}} too.
 
 %{toc|section=1|fromDepth=2|toDepth=3}
 
@@ -65,7 +66,6 @@ Maven Code Style And Code Conventions
 ** Java Code Style
 
  Maven adopts the {{{https://github.com/palantir/palantir-java-format}palantir Java format}}.
-
 
 ** Java Code Convention
 


### PR DESCRIPTION
MNGSITE-500 turned a bit from add a note about spotless to another "does anyone provide a formatter?", which is not part of site, but of shared-resources (where issues exists). As it's unclear when formatters for Eclipse and other IDE are provided in shared-resources, this PR adds a note about the IDE plugin offered by palantir itself (which are up to date, for example IntelliJ plugin was updated some days ago).