### PR TITLE
move /wrapper to /tools/wrapper with /tools-archives

### DIFF
--- a/content/apt/plugins/index.apt
+++ b/content/apt/plugins/index.apt
@@ -173,7 +173,7 @@ Available Plugins
 *--------------------------------------------------------------+------------+--------------+------------+------------------+------------------------+--------------------+
 | {{{/plugins/maven-toolchains-plugin/} <<<toolchains>>>}}     | B          | 3.2.0        | 2024-04-21 | Allows to share configuration across plugins. | {{{https://gitbox.apache.org/repos/asf/maven-toolchains-plugin.git}Git}} / {{{https://github.com/apache/maven-toolchains-plugin/}GitHub}} | {{{https://github.com/apache/maven-toolchains-plugin/issues}GitHub Issues}}
 *--------------------------------------------------------------+------------+--------------+------------+------------------+------------------------+--------------------+
-| {{{/plugins/maven-wrapper-plugin/} <<<wrapper>>>}}           | B          | 3.3.2        | 2024-05-24 | Download and unpack the maven wrapper distribution | {{{https://gitbox.apache.org/repos/asf/maven-wrapper-plugin.git}Git}} / {{{https://github.com/apache/maven-wrapper/}GitHub}} | {{{https://github.com/apache/maven-wrapper/issues}GitHub Issues}}
+| {{{/tools/wrapper/maven-wrapper-plugin/} <<<wrapper>>>}}     | B          | 3.3.2        | 2024-05-24 | Download and unpack the maven wrapper distribution | {{{https://gitbox.apache.org/repos/asf/maven-wrapper-plugin.git}Git}} / {{{https://github.com/apache/maven-wrapper/}GitHub}} | {{{https://github.com/apache/maven-wrapper/issues}GitHub Issues}}
 *--------------------------------------------------------------+------------+--------------+------------+------------------+------------------------+--------------------+
 
   \* <<B>>uild or <<R>>eporting plugin

--- a/content/filtered-resources/.htaccess
+++ b/content/filtered-resources/.htaccess
@@ -64,6 +64,8 @@ RedirectMatch permanent ^/shared/maven-plugin-testing-tools/(.*)$ /plugin-testin
 RedirectMatch permanent ^/shared/maven-plugin-tools/(.*)$ /plugin-tools/$1
 RedirectMatch permanent ^/[^/]+-archives/([^/\dLATES]+/.*)$ /$1
 RedirectMatch permanent ^/ref/3.1-SNAPSHOT/(.*)$ /ref/3-LATEST/$1
+RedirectMatch permanent ^/wrapper/(.*)$ /tools/wrapper/$1
+RedirectMatch permanent ^/wrapper-archives/(.*)$ /tools-archives/$1
 
 RedirectMatch permanent ^/plugins/maven-clover-plugin/([^2i].+)$ /plugins/maven-clover-plugin/2.4/$1
 RedirectMatch permanent ^/plugins/maven-clover-plugin/ins(.+)$ /plugins/maven-clover-plugin/2.4/ins$1

--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -31,6 +31,8 @@ select component category, then type artifact id and version to generate svn com
 <li><a href="?pom">poms</a></li>
 <li><a href="?resolver">resolver</a></li>
 <li><a href="?skins">skins</a></li>
+<li><a href="?extensions">extensions</a></li>
+<li><a href="?tools">tools</a></li>
 <li><a href="?doxia">Doxia</a></li>
 <li><a href="?doxia-sitetools">Doxia Sitetools</a></li>
 <li><a href="?doxia-tools">Doxia Tools</a></li>

--- a/content/resources/components.links
+++ b/content/resources/components.links
@@ -43,7 +43,7 @@ skins-archives=components/skins-archives
 studies=components/studies
 surefire-archives=components/surefire-archives
 surefire=components/surefire
+tools-archives=components/tools-archives
+#tools
 wagon-archives=components/wagon-archives
 wagon=components/wagon
-wrapper-archives=components/wrapper-archives
-wrapper=components/wrapper

--- a/content/resources/tools/components.links
+++ b/content/resources/tools/components.links
@@ -1,0 +1,3 @@
+# links property file for Ant's symlink task in pom.xml:
+# links to components in https://maven.apache.org/components
+wrapper=../components/tools/wrapper


### PR DESCRIPTION
with the creation of https://maven.apache.org/tools/ directory as part of #811 

it becomes natural to move Maven Wrapper from https://maven.apache.org/wrapper/ to https://maven.apache.org/tools/wrapper/

this PR does some aspects of smooth transition:
- create symlinks for https://maven.apache.org/tools/wrapper/ and https://maven.apache.org/tools-archives/
- do url redirects
- prepare [Component Release Documentation Helper](https://maven.apache.org/developers/website/component-reference-documentation-helper.html) for future releases 

just before merging this PR, content in svn website HTML will have to be prepared:
```
svnmucc -m "move /wrapper to /tools/wrapper (maven-site#838)" \
  -U https://svn.apache.org/repos/asf/maven/website/components \
  mv wrapper-archives tools-archives \
  mkdir tools \
  mv wrapper tools/wrapper
```

and wrapper site publication can later be changed to point to https://maven.apache.org/tools/wrapper/ (with breadcrumb to [tools directory](https://maven.apache.org/tools/))