### PR TITLE
correct resolver version mentioned in release notes

### DIFF
--- a/content/markdown/docs/3.9.11/release-notes.md
+++ b/content/markdown/docs/3.9.11/release-notes.md
@@ -44,7 +44,7 @@ The majority of fixed issues are bug and regression fixes for user reported prob
 
 Maven itself received new features - ability to control which repositories to be queried to resolve ranges.
 
-This release updates Resolver to version [1.9.22](https://github.com/apache/maven-resolver/releases/tag/maven-resolver-1.9.24).
+This release updates Resolver to version [1.9.24](https://github.com/apache/maven-resolver/releases/tag/maven-resolver-1.9.24).
 Resolver upgrade includes:
 
 - RFC9457 implementation - human-readable description details for HTTP problems


### PR DESCRIPTION
In the release notes of maven 3.9.11, it mentions the wrong resolver  version `1.9.22`, which should have been `1.9.24`.

Fixes https://github.com/apache/maven-site/issues/1337

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

