### PR TITLE
Update .htaccess to fix bad toolchains-1.1.0.xsd redirect

### DIFF
--- a/content/resources/xsd/.htaccess
+++ b/content/resources/xsd/.htaccess
@@ -5,7 +5,4 @@ Redirect /xsd/maven-4.1.0.xsd /xsd/maven-4.1.0-rc-4.xsd
 Redirect /xsd/plugin-2.0.0.xsd /xsd/plugin-2.0.0-rc-4.xsd
 Redirect /xsd/repository-metadata-1.2.0.xsd /xsd/repository-metadata-1.2.0-rc-4.xsd
 Redirect /xsd/settings-2.0.0.xsd /xsd/settings-2.0.0-rc-4.xsd
-Redirect /xsd/toolchains-1.1.0.xsd /xsd/toolchains-1.1.0-rc-3.xsd
-
-
 Redirect /xsd/toolchains-1.2.0.xsd /xsd/toolchains-1.2.0-rc-4.xsd


### PR DESCRIPTION
Removing redirect for `toolchains-1.1.0.xsd`, which has been released and is present in `content/resources/xsd`, but where a redirect to a non-existent rc-3 file is causing a 404.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

