### PR TITLE
Update index.apt with new OWASP Dependency-Check location

### DIFF
--- a/content/apt/plugins/index.apt
+++ b/content/apt/plugins/index.apt
@@ -264,7 +264,7 @@ Available Plugins
 *----------------------------------------------------------------------------+----------------+-----------------------+
 | {{{https://tomcat.apache.org/maven-plugin.html} <<<Apache Tomcat>>>}}| {{{https://tomcat.apache.org/maven-plugin.html}Apache Tomcat Project}} | Run an Apache Tomcat container for rapid webapp development.
 *----------------------------------------------------------------------------+----------------+-----------------------+
-| {{{https://jeremylong.github.io/DependencyCheck/} <<<OWASP dependency-check>>>}} | {{{https://www.owasp.org/index.php/OWASP_Dependency_Check}OWASP Dependency-check Project}} | Run OWASP Dependency-Check, a utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities.
+| {{{https://dependency-check.github.io/DependencyCheck/} <<<OWASP dependency-check>>>}} | {{{https://www.owasp.org/index.php/OWASP_Dependency_Check}OWASP Dependency-check Project}} | Run OWASP Dependency-Check, a utility that identifies project dependencies and checks if there are any known, publicly disclosed, vulnerabilities.
 *----------------------------------------------------------------------------+----------------+-----------------------+
 | {{{https://github.com/CycloneDX/cyclonedx-maven-plugin} <<<CycloneDX>>>}}  | {{{https://cyclonedx.org/}CycloneDX Project}} | Generate Software Bill of Materials (SBOM) in CycloneDX format.
 *----------------------------------------------------------------------------+----------------+-----------------------+


### PR DESCRIPTION
The architect/developer at OWASP has moved the plugin for Dependency-Check under the main [github.com/dependency-check/](https://github.com/dependency-check/) umbrella from his personal account.

The prior repository has been frozen on GitHub with a note, found at [https://github.com/jeremylong/DependencyCheck](https://github.com/jeremylong/DependencyCheck).

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [X] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

