### PR TITLE
Fix escapeRegExp function in documentation-helper

### DIFF
--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -81,7 +81,7 @@ function selectCategory(index, archive) {
 }
 
 function escapeRegExp(string) {
-    return string.replace(/([.*+?^=!:${}()|[]\/\])/g, "\\$1");
+    return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
 }
 function replaceAll(string, find, replace) {
   return string.replace(new RegExp(escapeRegExp(find), 'g'), replace);


### PR DESCRIPTION
revert change from: 
 - fdc93a1f476c76d89f6db137aee20c7f12eb820e
 - #1361

https://maven.apache.org/developers/website/component-reference-documentation-helper.html