### PR TITLE
Require status checks - block direct push

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,7 +32,11 @@ github:
     - FELIX
     - MRELEASE
   protected_branches:
-    master: {}
+    master:
+      required_status_checks:
+        # contexts are the names of checks that must pass.
+        contexts:
+          - Verify and build Maven Site
     master-test:
       required_status_checks:
         # contexts are the names of checks that must pass.

--- a/.github/workflows/verify-site.yml
+++ b/.github/workflows/verify-site.yml
@@ -28,6 +28,7 @@ permissions: {}
 
 jobs:
   build:
+    # don't change the name without updating the .asf.yaml
     name: Verify and build Maven Site
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- each commit must be done by PR to GitHub
- direct commit will be blocks to GitHub and to ASF gitbox
- build on GitHub must pass
- PR review is not required

As project is not releases should be not a problem to enable it.

It should protect us by broken master build


