### PR TITLE
Dropped Use and renamed Run to Use in the About Maven section

### DIFF
--- a/content/site.xml
+++ b/content/site.xml
@@ -45,9 +45,7 @@ under the License.
       <item name="What is Maven?" href="/what-is-maven.html"/>
       <item name="Installation" href="/install.html" />
       <item name="Downloads" href="/download.html"/>
-      <item name="Use" href="/users/index.html" collapse="true">
-      </item>
-      <item name="Run" href="/run.html"/>
+      <item name="Use" href="/run.html"/>
       <item name="Configure" href="/configure.html"/>
       <item name="Release Notes" href="/docs/history.html"/>
     </menu>


### PR DESCRIPTION
Having _Run_ and _Use_ in the navigation is confusing.

Most people, me included, expect the contents of the menu item _Run_ to show up when clicking  _Use_.

I don't think the menu item _Use_ adds much on itself in the About Maven section, therefore I would suggest removing it.