### PR TITLE
Downloads instead of Download

### DIFF
--- a/content/site.xml
+++ b/content/site.xml
@@ -29,7 +29,7 @@ under the License.
 
   <body>
     <links>
-      <item name="Download" href="/download.cgi"/>
+      <item name="Downloads" href="/download.cgi"/>
       <item name="Get Sources" href="/scm.html"/>
     </links>
     <breadcrumbs>


### PR DESCRIPTION
It says Download in the top navigation bar. Should be Downloads. 

It says Downloads in the left side navigation. Both link to the same page.
There is more than one thing to download. Downloads is better.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

