### PR TITLE
Tidied up download page

### DIFF
--- a/content/site.xml
+++ b/content/site.xml
@@ -29,7 +29,7 @@ under the License.
 
   <body>
     <links>
-      <item name="Download" href="/download.cgi"/>
+      <item name="Downloads" href="/download.cgi"/>
       <item name="Get Sources" href="/scm.html"/>
     </links>
     <breadcrumbs>


### PR DESCRIPTION
Hello,

my try on improving the Downloads page.

System requirements are now inline with the text. I don't think there is a need for everything mentioned and it is less visually dominated now.

Other releases is removed and its content is moved into Apache Maven and Maven Daemon. Daemon got its own section. If it were my call I would even go as far and drop Maven Daemon from the Downloads page. Not saying it is great tech, but the page is about downloading Maven not about Daemon.

I swapped the position of 4.x and older 3.8.x. I think this is better. Always nice to show that things are moving forward, but not ignoring the older versions.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

