### PR TITLE
Add note about milestone after release

### DIFF
--- a/content/markdown/developers/release/maven-project-release-procedure.md
+++ b/content/markdown/developers/release/maven-project-release-procedure.md
@@ -237,7 +237,9 @@ Once the release is deemed fit for public consumption it can be transferred to a
 
    Note: PR merged after release but before publishing can add next items to release notes draft.
 
-   Enable **Release Drafter** workflow on **GitHub** if was disabled during vote.
+   Enable **Release Drafter** workflow on **GitHub** if it was disabled during vote.
+   
+   Close milestone and create a new one for the branch, so PR merged can be associated with the new release.
 
 4. Wait for everything to sync
 


### PR DESCRIPTION
The release drafter needs milestones to associate PR with a release. During the GH issue migration the milestone setup was done for all repositories. Since then several releases were done, often resulting in invalid milestone setup in those repositories as milestones were not closed and no new ones were created, resulting in non or multiple milestones for a current branch (often no specific, so master).

This PR adds a note to the description of the release process to remind about handling milestones.