### PR TITLE
activate Fluido skins's anchorJs

### DIFF
--- a/content/site.xml
+++ b/content/site.xml
@@ -27,6 +27,12 @@ under the License.
 
   <edit>${project.scm.url}</edit>
 
+  <custom>
+    <fluidoSkin>
+      <anchorJs />
+    </fluidoSkin>
+  </custom>
+
   <body>
     <links>
       <item name="Downloads" href="/download.cgi"/>


### PR DESCRIPTION
= feature from Fluido skin https://maven.apache.org/skins/maven-fluido-skin/#AnchorJS

was active by default in Fluido 1.10.0 https://issues.apache.org/jira/browse/MSKINS-167
made an option, disabled by default, in Fluido 2.0.0 https://issues.apache.org/jira/browse/MSKINS-226

we just forgot to activate for our website: now done