### PR TITLE
developers/index.md: align title with site.xml

### DIFF
--- a/content/markdown/developers/index.md
+++ b/content/markdown/developers/index.md
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Developing Maven
+# Contribute to Maven
 
 This documentation is for people who work on the source code of Maven itself and its core plugins, or who would like to contribute. If you simply use Maven to build your own projects, it won't be very helpful.
 


### PR DESCRIPTION
Since 498279dbf9b9f2f95908f3ae64995640e07bc537, site.xml refers to /developers/index.html as "Contribute to Maven" instead of "Maven Developer Centre"; however, the title in /developers/index.html has not been updated accordingly.  This change fixes it.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [X] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

