### PR TITLE
[#12288] Doc: <activation> limit on resolver-config profiles

### DIFF
--- a/content/markdown/guides/introduction/introduction-to-profiles.md
+++ b/content/markdown/guides/introduction/introduction-to-profiles.md
@@ -126,6 +126,8 @@ Example to set a profile active by default.
 </profiles>
 ```
 
+**Note for resolver configuration:** When configuring [Maven Resolver](../mini/guide-resolver-transport.html#system-level) low-level options (`aether.*` system properties) in a `settings.xml` profile, `<activeByDefault>true</activeByDefault>` does **not** suffice -- the resolver session is built before profile activation conditions are evaluated. List the profile id under `<activeProfiles>` (or pass `-P <id>`) instead.
+
 ##### JDK
 
 The following configuration will trigger the profile when the JDK's version _starts with_ `1.4` (for example `1.4.0_08`, `1.4.2_07`, `1.4`), in particular it _won't be active_ for **newer** versions like `1.8` or `11`:

--- a/content/markdown/guides/mini/guide-resolver-transport.md
+++ b/content/markdown/guides/mini/guide-resolver-transport.md
@@ -148,8 +148,7 @@ Configuration can be provided on global level as properties in `settings.xml`
 </settings>
 ```
 
-**NOTICE**
-- only profiles activated by `settings/activeProfiles` will be taken for consideration - you can not use `profile/activation` in such case
+**NOTICE:** Only profiles activated by `settings/activeProfiles` (the explicit list at the bottom of `settings.xml`) are honored here, or by CLI `-P <id>`. Profiles activated through `<activation>` conditions in the profile itself (`<activeByDefault>`, `<jdk>`, `<os>`, `<property>`, `<file>`) are **not** taken into account for the resolver session config -- the resolver session is built before Maven evaluates those conditions.
 
 You can also use environment variable `MAVEN_OPTS` ot `MAVEN_ARGS`
 

--- a/content/markdown/guides/mini/guide-resolver-transport.md
+++ b/content/markdown/guides/mini/guide-resolver-transport.md
@@ -148,9 +148,14 @@ Configuration can be provided on global level as properties in `settings.xml`
 </settings>
 ```
 
-**NOTICE:** Only profiles activated by `settings/activeProfiles` (the explicit list at the bottom of `settings.xml`) are honored here, or by CLI `-P <id>`. Profiles activated through `<activation>` conditions in the profile itself (`<activeByDefault>`, `<jdk>`, `<os>`, `<property>`, `<file>`) are **not** taken into account for the resolver session config -- the resolver session is built before Maven evaluates those conditions.
+**NOTICE:** Only profiles activated explicitly are honored here:
 
-You can also use environment variable `MAVEN_OPTS` ot `MAVEN_ARGS`
+* via `<activeProfiles>` (the explicit list at the bottom of `settings.xml`), or
+* via CLI `-P <id>`.
+
+Profiles activated through `<activation>` conditions in the profile itself — `<activeByDefault>`, `<jdk>`, `<os>`, `<property>`, `<file>` — are **not** taken into account for the resolver session config: the resolver session is built before Maven evaluates those conditions.
+
+You can also use environment variable `MAVEN_OPTS` or `MAVEN_ARGS`
 
 ```
 export MAVEN_ARGS="-Daether.connector.http.preemptiveAuth=true"


### PR DESCRIPTION
> **Status update 2026-06-23**:
>
> * **Fix for `<activeByDefault>` channel**: merged on apache/maven master via
>   [#12297](https://github.com/apache/maven/pull/12297) +
>   [#12298](https://github.com/apache/maven/pull/12298). Backports open:
>   [#12299](https://github.com/apache/maven/pull/12299) (`maven-4.0.x`) and
>   [#12333](https://github.com/apache/maven/pull/12333) (`maven-3.10.x`).
>   IT backport: [apache/maven-integration-testing#428](https://github.com/apache/maven-integration-testing/pull/428).
> * **WARN for the remaining four channels** (`<jdk>`, `<os>`, `<property>`,
>   `<file>`) — still under discussion at [#12288](https://github.com/apache/maven/issues/12288).
>   Doc wording is independent of that decision; this PR can land now.

## What this PR does

Two doc clarifications around the long-standing limitation that `aether.*` properties declared inside a `settings.xml` profile only take effect if the profile is listed under `<activeProfiles>` or activated via CLI `-P`. The limitation has been documented since [MNG-7850](https://issues.apache.org/jira/browse/MNG-7850) (2023, by @slawekjaranowski) but only in the resolver-transport mini-guide; profile-side users would never find it.

* `guides/mini/guide-resolver-transport.md` — strengthen the NOTICE so it enumerates what the limitation actually covers (all `<activation>` conditions, not just `activeByDefault`) and gives a one-line rationale.
* `guides/introduction/introduction-to-profiles.md` — add a single sentence in the "Active by default" section linking to the mini-guide caveat, so users planning to use `<activeByDefault>` for `aether.*` config are warned where they actually look.

## Versions affected

* Maven 3.x ≤ 3.10.0-SNAPSHOT (before #12333 lands).
* Maven 4 4.0.0-rc-5 and earlier (4.0.x with #12299 ships fixed).
* Maven 4 master 4.1.0-SNAPSHOT and later **fixed** via #12297.

The doc page describes a limitation that exists in every Maven release on the user's path; it remains accurate for years of running releases. The "remaining four channels" caveat (`<jdk>`, `<os>`, etc.) is true regardless of whether a WARN is added later.