### PR TITLE
Fix numbered list not continuing in pom.html.

### DIFF
--- a/content/markdown/pom.md
+++ b/content/markdown/pom.md
@@ -225,15 +225,15 @@ There are three methods for dealing with this scenario.
 
 1. Install the dependency locally using the *Maven Install Plugin*. The method is the simplest recommended method. For example:
 
-```
-mvn install:install-file -Dfile=non-maven-proj.jar -DgroupId=some.group -DartifactId=non-maven-proj -Dversion=1 -Dpackaging=jar
-```
+    ```
+    mvn install:install-file -Dfile=non-maven-proj.jar -DgroupId=some.group -DartifactId=non-maven-proj -Dversion=1 -Dpackaging=jar
+    ```
 
-Notice that an address is still required, only this time you use the command line and the Maven Install Plugin will create a POM for you with the given address.
+    Notice that an address is still required, only this time you use the command line and the Maven Install Plugin will create a POM for you with the given address.
 
-2. Create your own repository and deploy it there. This is a favorite method for companies with an intranet and need to be able to keep everyone in synch. There is a Maven goal called `deploy:deploy-file` which is similar to the `install:install-file` goal (read the plugin's goal page for more information).
+1. Create your own repository and deploy it there. This is a favorite method for companies with an intranet and need to be able to keep everyone in synch. There is a Maven goal called `deploy:deploy-file` which is similar to the `install:install-file` goal (read the plugin's goal page for more information).
 
-3. Set the dependency scope to `system` and define a `systemPath`. This is not recommended, however, but leads us to explaining the following elements:
+1. Set the dependency scope to `system` and define a `systemPath`. This is not recommended, however, but leads us to explaining the following elements:
 
 * `<classifier>`:
   The classifier distinguishes artifacts that were built from the same POM but differ in content.


### PR DESCRIPTION
Documentation mentions:

> There are three methods for dealing with this scenario

But the numbered list count is broken up.

Current:
======<img width="405" height="325" alt="be4" src="https://github.com/user-attachments/assets/8af76e94-eb67-48d8-9c77-1f506409e164" />

---
Fix:
======<img width="360" height="300" alt="eakfjewkj" src="https://github.com/user-attachments/assets/70096ed4-3c73-4bd4-a3f9-f37faf71ca8d" />



----
Following this checklist to help us incorporate your
contribution quickly and easily:


- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Run `mvn site` and examine output in `target/site` directory.
  Site will also be built on your pull request automatically and attached to GitHub Action result.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

