### PR TITLE
docs: correct non-existent bomClassifier element in What's new in Maven 4

### DIFF
--- a/content/markdown/whatsnewinmaven4.md
+++ b/content/markdown/whatsnewinmaven4.md
@@ -170,9 +170,8 @@ standard `<classifier>` element on the import dependency:
 </dependencyManagement>
 ```
 
-There is no dedicated `<bomClassifier>` element in the POM model or XSD.
 Classified BOM artifacts are produced by attaching an additional POM artifact with a classifier (for example via a
-BOM-building plugin), not by a model element on the producing project.
+BOM-building plugin). Consumers import that artifact with the standard `<classifier>` element as shown above.
 
 Therefore, the Maven team suggests that project BOMs should be published as classified artifacts when appropriate.
 This means that an imported BOM must **not** come from the same reactor as the current build but be available outside

--- a/content/markdown/whatsnewinmaven4.md
+++ b/content/markdown/whatsnewinmaven4.md
@@ -152,9 +152,29 @@ the [live coding by Maven maintainer Karl Heinz Marbaise at IntelliJ IDEA Conf 2
 
 **Note**: With Maven 4, it's also possible to exclude dependencies that are declared by BOMs using the existing
 `<exclusions>` element.
-Also note that in Maven 4, importing BOMs with a classifier is now possible.
-Therefore, the Maven team suggests that project BOMs should be generated as classified artifacts, using the
-`<bomClassifier>` element.
+Also note that in Maven 4 (model version 4.1.0 and later), importing BOMs with a classifier is possible by using the
+standard `<classifier>` element on the import dependency:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>example</artifactId>
+      <version>1.0.0</version>
+      <type>pom</type>
+      <classifier>bom</classifier>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
+There is no dedicated `<bomClassifier>` element in the POM model or XSD.
+Classified BOM artifacts are produced by attaching an additional POM artifact with a classifier (for example via a
+BOM-building plugin), not by a model element on the producing project.
+
+Therefore, the Maven team suggests that project BOMs should be published as classified artifacts when appropriate.
 This means that an imported BOM must **not** come from the same reactor as the current build but be available outside
 the project before the build.
 In other words: you should only import external BOMs.


### PR DESCRIPTION
## Summary

Fixes [apache/maven#12661](https://github.com/apache/maven/issues/12661).

The [What's new in Maven 4](https://maven.apache.org/whatsnewinmaven4.html#new-packaging-type-bom) page claimed that project BOMs should be generated using a `<bomClassifier>` element. That element does not exist in the Maven 4.1.0 model or XSD, and there is no example of how to use it.

### Investigation

| Claim | Reality |
|-------|---------|
| `<bomClassifier>` POM element | **Does not exist** in `maven.mdo` / XSD 4.1.0 |
| Import BOM with classifier | **Supported** for model 4.1.0+ via standard dependency `<classifier>` (validator skips the "must be empty" rule when `is41OrBeyond`) |
| Generating classified BOMs | Done by attaching an additional POM artifact with a classifier (e.g. plugin config such as `bom-builder3`'s `bomClassifier` parameter) — not a model element |

This is a documentation correctness fix only (no model/XSD change).

### Changes

- Replace the false `<bomClassifier>` reference with the real import syntax using `<classifier>`
- Add a short import example
- Clarify that classified BOMs are attached artifacts, not a POM model element
- Keep the existing guidance about importing only external (non-reactor) BOMs

## Testing

- Docs-only change; no code build required
- Reviewed against `DefaultModelValidator` (classifier allowed for import scope when model ≥ 4.1.0) and confirmed no `bomClassifier` field in `api/maven-api-model`

## Checklist

- [x] Addresses a single issue without unrelated changes
- [x] Meaningful commit message
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)