### PR TITLE
Lead with Markdown in the site and plugin documentation guides

### DIFF
--- a/content/markdown/guides/development/guide-plugin-documentation.md.vm
+++ b/content/markdown/guides/development/guide-plugin-documentation.md.vm
@@ -202,57 +202,61 @@ Below is the suggested site descriptor template (with maven-fluido-skin).
 
 - Introduction
 
-    The introduction is the front page of the plugin documentation. This is a good place to put any section and pages that need to be emphasized. The generated plugin parameter configuration should be linked here. Below is the suggested `src/site/apt/index.apt` template:
+    The introduction is the front page of the plugin documentation. This is a good place to put any section and pages that need to be emphasized. The generated plugin parameter configuration should be linked here. Below is the suggested `src/site/markdown/index.md` template:
 
+    ```markdown
+    #[[
+    ---
+    title: Introduction
+    author:
+      - Author
+    date: YYYY-MM-DD
+    ---
+
+    # Plugin Name
+
+    Plugin introduction, description, and other relevant information.
+
+    ## Goals Overview
+
+    General information about the goals.
+
+    - [prefix:goal](<goal>.html) short description for this plugin goal.
+
+    ## Usage
+
+    General instructions for using the Plugin Name can be found on the [usage page](usage.html). Some more
+    specific use cases are described in the examples given below. Last but not least, users occasionally contribute
+    additional examples, tips or errata to the plugin's wiki page.
+
+    If you have questions regarding the plugin, consult the [FAQ](faq.html) and feel
+    free to contact the [user mailing list](mailing-lists.html). Posts to the mailing list are archived and might
+    already contain the answer to your question. Hence, it is also worth browsing/searching
+    the [mail archive](mailing-lists.html).
+
+    If you think the plugin is missing a feature or has a defect, you can file a feature request or bug report in the
+    [issue management system](issue-management.html). When creating a new issue, please provide a comprehensive description of your
+    concern. Especially for fixing bugs, it is crucial that the developers can reproduce your problem. For this reason,
+    entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
+    Of course, patches are welcome, too. Contributors can check out the project from our
+    [source repository](scm.html) and will find supplementary information in the
+    [guide to helping with Maven](/guides/development/guide-helping.html).
+
+    ## Examples
+
+    To help you understand some usages of the Plugin Name,
+    you can take a look at the following examples:
+
+    - [Example Description One](./examples/example-one.html)
+    - [Example Description Two](./examples/example-two.html)
+    ]]#
     ```
-     ------
-     Introduction
-     ------
-     Author
-     ------
-     YYYY-MM-DD
-     ------
-    
-    
-    Plugin Name
-    
-      Plugin introduction, description, and other relevant information.
-    
-    * Goals Overview
-    
-      General information about the goals.
-    
-      * {{{<goal>.html}prefix:goal}} short description for this plugin goal.
-    
-    * Usage
-    
-      General instructions for using the Plugin Name can be found on the {{{usage.html}usage page}}. Some more
-      specific use cases are described in the examples given below. Last but not least, users occasionally contribute
-      additional examples, tips or errata to the plugin's wiki page.
-    
-      If you have questions regarding the plugin, consult the {{{faq.html}FAQ}} and feel
-      free to contact the {{{mailing-lists.html}user mailing list}}. Posts to the mailing list are archived and might
-      already contain the answer to your question. Hence, it is also worth browsing/searching
-      the {{{mailing-lists.html}mail archive}}.
-    
-      If you think the plugin is missing a feature or has a defect, you can file a feature request or bug report in the
-      {{{issue-management.html}issue management system}}. When creating a new issue, please provide a comprehensive description of your
-      concern. Especially for fixing bugs, it is crucial that the developers can reproduce your problem. For this reason,
-      entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
-      Of course, patches are welcome, too. Contributors can check out the project from our
-      {{{scm.html}source repository}} and will find supplementary information in the
-      {{{/guides/development/guide-helping.html}guide to helping with Maven}}. 
-    
-    * Examples
-    
-      To help you understand some usages of the Plugin Name,
-      you can take a look at the following examples:
-    
-      * {{{./examples/example-one.html}Example Description One}}
-    
-      * {{{./examples/example-two.html}Example Description Two}}
-    
-    ```
+
+    The `---` block at the top carries the page title, author and date; the site skin turns
+    them into the document title and its `author` and `date` meta tags. If the page needs
+    Velocity — to interpolate a version into an example POM, say — name it `index.md.vm`
+    instead, and keep headings below level one away from `##`, which Velocity reads as a
+    line comment.
 
 - Goals
 

--- a/content/markdown/guides/mini/guide-site.md
+++ b/content/markdown/guides/mini/guide-site.md
@@ -26,11 +26,11 @@ The first step to creating your site is to create some content. In Maven, the si
 ```
 +- src/
    +- site/
-      +- apt/
-      |  +- index.apt
-      !
       +- markdown/
-      |  +- content.md
+      |  +- index.md
+      |
+      +- apt/
+      |  +- content.apt
       |
       +- fml/
       |  +- general.fml
@@ -46,8 +46,8 @@ You will notice there is now a `${project.basedir}/src/site` directory within wh
 
 Let's take a look at the examples of the various document types:
 
-- `apt`: the APT format, "Almost Plain Text", is a wiki-like format that allows you to write simple, structured documents (like this one) very quickly. A full reference of the [APT Format](/doxia/references/apt-format.html) is available,
-- `markdown`: the well known [Markdown](https://en.wikipedia.org/wiki/Markdown) format,
+- `markdown`: the well known [Markdown](https://en.wikipedia.org/wiki/Markdown) format, and the one this page is written in. It is what new documentation should use,
+- `apt`: the APT format, "Almost Plain Text", a wiki-like format that predates Maven's support for Markdown. It is still supported, but the Maven project itself has moved its own documentation off it; see the [APT Format](/doxia/references/apt-format.html) reference if you are maintaining an existing page, and [doxia-converter](/doxia/doxia-tools/doxia-converter/) if you would like to convert one,
 - `fml`: the FML format is the [FAQ format](/doxia/references/fml-format.html),
 - `xdoc`: an XML document conforming to a small and simple set of tags, see the [full reference](/doxia/references/xdoc-format.html).
 


### PR DESCRIPTION
Sits on top of #1632 — the first two commits here are that PR, since the plugin documentation guide has to be Markdown before its content can be rewritten. **Review the last commit only**; once #1632 merges this will rebase down to two files.

Two pieces of normative guidance still point new documentation at APT:

**`guides/mini/guide-site.md`** lists `apt` first and calls it the format "like this one" — which stopped being true when that guide itself became Markdown. It now lists `markdown` first, says plainly that new documentation should use it, and describes APT as a format that predates Maven's Markdown support: still supported, but the Maven project has moved its own documentation off it. Adds a pointer to `doxia-converter` for anyone converting an existing page.

**`guides/development/guide-plugin-documentation`** is the canonical instruction for documenting a plugin, and it gave a full APT template for `src/site/apt/index.apt` — so an author following it started in APT. It now shows the same page as `src/site/markdown/index.md`, with the YAML front matter that carries the title, author and date, plus a note about naming the file `index.md.vm` and keeping headings away from `##` if the page needs Velocity.

One thing worth seeing: that guide is itself a Velocity template, and Velocity reads `##` as a line comment **even inside a fenced code block**. The first version of this change silently lost `## Goals Overview` and `## Usage` from the rendered sample. It is now wrapped in `#[[ ]]#`. That only showed up because the built page was checked rather than the source.

Verified by building the site: the sample renders all its headings and no `#[[` markup leaks into the page.