### PR TITLE
Update settings XSD references from 1.0.0 to 1.2.0 (#1598)

### DIFF
--- a/content/markdown/general.md
+++ b/content/markdown/general.md
@@ -274,7 +274,7 @@ the [Guide to Plugin Snapshot Repositories](/guides/development/guide-testing-de
 See the following links:
 
 - [Maven XSD](/xsd/maven-4.0.0.xsd)
-- [Maven Settings XSD](/xsd/settings-1.0.0.xsd)
+- [Maven Settings XSD](/xsd/settings-1.2.0.xsd)
 
 Your favorite IDE probably supports XSD schema's for `pom.xml` and `settings.xml` editing.
 You need to specify the following:
@@ -292,10 +292,10 @@ You need to specify the following:
 
 ```xml
 
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0
+                      https://maven.apache.org/xsd/settings-1.2.0.xsd">
 
   <!-- ... -->
 </settings>

--- a/content/markdown/guides/getting-started/index.md
+++ b/content/markdown/guides/getting-started/index.md
@@ -848,8 +848,8 @@ Here is an example using scp and username/password authentication:
 ```
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
   ...
   <servers>
     <server>

--- a/content/markdown/settings.md
+++ b/content/markdown/settings.md
@@ -50,8 +50,8 @@ your needs.
 Here is an overview of the top elements under `settings`:
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
   <localRepository/>
   <interactiveMode/>
   <offline/>
@@ -81,8 +81,8 @@ Half of the top-level `settings` elements are simple values,
 representing a range of values which describe elements of the build
 system that are active full-time.
 
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
           <localRepository>${user.home}/.m2/repository</localRepository>
           <interactiveMode>true</interactiveMode>
           <offline>false</offline>
@@ -109,7 +109,7 @@ not provided in the command line. This list automatically contains
 `org.apache.maven.plugins` and `org.codehaus.mojo`.
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <pluginGroups>
     <pluginGroup>org.eclipse.jetty</pluginGroup>
@@ -133,7 +133,7 @@ should not be distributed along with the `pom.xml`. This type of
 information should exist on the build server in the `settings.xml`.
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <servers>
     <server>
@@ -179,7 +179,7 @@ page](./guides/mini/guide-encryption.html)
 ### Mirrors
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <mirrors>
     <mirror>
@@ -212,7 +212,7 @@ Mirror Settings](./guides/mini/guide-mirror-settings.html).
 ### Proxies
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <proxies>
     <proxy>
@@ -265,7 +265,7 @@ certain circumstances; those circumstances are specified via an
 `activation` element.
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   <!-- ... -->
   <profiles>
     <profile>
@@ -353,7 +353,7 @@ all accessible from the `settings.xml` file:
 <!-- -->
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <profiles>
     <profile>
@@ -381,7 +381,7 @@ profile they may be searched for a matching release or snapshot
 artifact.
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <profiles>
     <profile>
@@ -461,7 +461,7 @@ Maven can find new plugins.
 ### Active Profiles
 
 ```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
   ...
   <activeProfiles>
     <activeProfile>env-test</activeProfile>


### PR DESCRIPTION
Fixes #1598

The Settings Reference and related pages referenced the outdated `settings-1.0.0.xsd` schema, while the current Maven (e.g. 3.9.16) uses `settings-1.2.0.xsd`. A settings.xml validated against the 1.0.0 XSD rejects valid tags like `<usePluginRegistry/>`, `<mirrorOfLayouts>`, and `<blocked>`.

Updated all references from `SETTINGS/1.0.0` / `settings-1.0.0.xsd` to `SETTINGS/1.2.0` / `settings-1.2.0.xsd`:

- `content/markdown/settings.md` (Settings Reference, including the quickstart overview)
- `content/markdown/general.md` (XSD schemas links + example)
- `content/markdown/guides/getting-started/index.md` (getting-started example)