### PR TITLE
Drop the version.maven-fluido-skin property the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,6 @@
     <site.output>${project.build.directory}/site</site.output>
     <javaVersion>17</javaVersion>
     <siteDirectory>${project.basedir}/content</siteDirectory>
-    <!-- used by src/xdoc/errors/404.xml.vm as well -->
-    <version.maven-fluido-skin>2.1.0</version.maven-fluido-skin>
     <version.plantuml-maven-plugin>0.4.16</version.plantuml-maven-plugin>
     <!-- required by plantuml-m-p 0.3 -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>


### PR DESCRIPTION
`org.apache:apache:39` already sets `version.maven-fluido-skin` to **2.1.0** — the identical value — so the local property restates what is inherited and simply has to be kept in step with the parent by hand.

### The `<!-- used by ... 404.xml.vm as well -->` comment — checked, it does not break

That comment is a real warning, so it was worth testing rather than assuming. Two Velocity templates read the property:

- `content/xdoc/errors/404.xml.vm` — builds the skin's CSS and JS URLs
- `content/markdown/guides/development/guide-plugin-documentation.md.vm`

both through `${context.get("version.maven-fluido-skin")}`.

maven-site-plugin builds the Velocity context from the project's **effective** properties, which include everything inherited, so `context.get()` cannot tell a local property from a parent's. Verified rather than assumed — a probe page rendered against maven-site-plugin 3.22.0 with the property declared **only in a parent pom**:

```
INHERITED=[INHERITED-2.1.0]     <- declared only in the parent
LOCAL=[LOCAL-9.9.9]             <- declared in the module
```

Both resolve. So the two templates keep rendering exactly as before, with the same 2.1.0 value.

If anything the coupling gets slightly better: the 404 page now names whatever skin the site was actually built with, instead of a hand-maintained copy that can drift from it. The CSS and JS it links are deployed by that same site build.

The comment is removed along with the property — it would otherwise sit above `version.plantuml-maven-plugin` and describe it wrongly. It had also gone stale in another way: it points at `src/xdoc`, a path this repository stopped using when the content moved under `content/`.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything.

Generated-by: Claude Opus 5 (1M context)
