### PR TITLE
Update the report plugin guide to the Doxia 2.0.0 stack

### DIFF
--- a/content/markdown/guides/plugin/guide-java-report-plugin-development.md.vm
+++ b/content/markdown/guides/plugin/guide-java-report-plugin-development.md.vm
@@ -71,7 +71,8 @@ An easy way to implement both `Mojo` and `MavenReport` interfaces is to extend t
 
 The class will need to implement the following methods:
 
-- `public String getOutputName()`: returns the name of page that will be produced
+- `public String getOutputPath()`: returns the path of the page that will be produced
+- `public String getOutputName()`: deprecated in favour of `getOutputPath()`, but still declared abstract by `MavenReport`, so it has to be implemented — delegate it to `getOutputPath()`
 - `public String getName(Locale locale)`: returns the display name of the report
 - `public String getDescription(Locale locale)`: returns the description of the report
 - `protected void executeReport(Locale locale) throws MavenReportException`: produces the actual report
@@ -115,8 +116,8 @@ The below examples can be copied and pasted as a template.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <doxiaVersion>1.10</doxiaVersion>
-        <doxiaSitetoolsVersion>1.10</doxiaSitetoolsVersion>
+        <doxiaVersion>2.1.0</doxiaVersion>
+        <doxiaSitetoolsVersion>2.1.0</doxiaSitetoolsVersion>
     </properties>
 
     <dependencies>
@@ -136,19 +137,25 @@ The below examples can be copied and pasted as a template.
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-impl</artifactId>
-            <version>3.0.0</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-api</artifactId>
-            <version>3.0</version>
+            <version>4.0.0</version>
         </dependency>
 
         <!-- plugin API and plugin-tools -->
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.9.11</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.2</version>
+            <version>3.9.11</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -157,12 +164,6 @@ The below examples can be copied and pasted as a template.
             <version>$context.get("version.maven-plugin-tools")</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-
     </dependencies>
 
 
@@ -209,7 +210,6 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
@@ -232,7 +232,17 @@ import org.apache.maven.reporting.MavenReportException;
      )
 public class SimpleReport extends AbstractMavenReport {
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    @Override
+    public String getOutputPath() {
         // This report will generate simple-report.html when invoked in a project with `mvn site`
         return "simple-report";
     }
@@ -248,12 +258,6 @@ public class SimpleReport extends AbstractMavenReport {
         + "shows off Maven's wonderful reporting capabilities.";
     }
 
-    /**
-     * Practical reference to the Maven project
-     */
-    @Parameter(defaultValue = "\${project}", readonly = true)
-    private MavenProject project;
-
     @Override
     protected void executeReport(Locale locale) throws MavenReportException {
 
@@ -261,7 +265,7 @@ public class SimpleReport extends AbstractMavenReport {
         Log logger = getLog();
 
         // Some info
-        logger.info("Generating " + getOutputName() + ".html"
+        logger.info("Generating " + getOutputPath() + ".html"
                 + " for " + project.getName() + " " + project.getVersion());
 
         // Get the Maven Doxia Sink, which will be used to generate the


### PR DESCRIPTION
The template on this page built against Doxia 1.10, `maven-reporting-impl` 3.0.0 and
`maven-reporting-api` 3.0, so anyone following it today writes a new plugin against the stack
that was superseded by Doxia 2.0.0.

Beyond the version numbers, three things the bump alone does not give you:

- `MavenProject` no longer arrives transitively — `maven-reporting-impl` 4.0.0 declares `maven-core`
  as `provided`, so the sample needs its own `provided` `maven-core` or it does not compile.
- `getOutputName()` is deprecated in 4.0.0 but still abstract on `MavenReport`, so it cannot simply
  be replaced. The sample now implements `getOutputPath()` and delegates the deprecated method to
  it, matching what `maven-javadoc-plugin` does.
- `AbstractMavenReport` already declares `protected MavenProject project`, so the sample's own
  `@Parameter`-annotated field was shadowing it; removed.

The unused `maven-shared-utils` dependency is dropped in the same pass — nothing in the sample
imports it.

Verified: built the page's two samples as a real plugin, `mvn install`, then ran `mvn site` on a
consumer project declaring it under `<reporting>` — `target/site/simple-report.html` is generated
and listed in `project-reports.html`, and the compile is free of deprecation warnings. The blocks in
the page are byte-identical to what was built.

*This change was created with AI assistance.*
