### PR TITLE
Restore page metadata lost in the xdoc to Markdown migration

### DIFF
--- a/content/markdown/articles.md
+++ b/content/markdown/articles.md
@@ -1,3 +1,10 @@
+---
+title: External Resources on Maven
+author:
+  - Brett Porter
+  - Vincent Massol
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,12 +23,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-<head>
-   <title>External Resources on Maven</title>
-   <meta name="author" content="Brett Porter" />
-   <meta name="author" content="Vincent Massol" />
-</head>
 
 # External Resources on Maven
 

--- a/content/markdown/developers/mojo-api-specification.md
+++ b/content/markdown/developers/mojo-api-specification.md
@@ -1,3 +1,8 @@
+---
+title: Mojo API Specification
+author: John Casey
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,11 +21,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-<head>
-   <title>Mojo API Specification</title>
-   <meta name="author" content="John Casey" />
-</head>
 
 # Mojo API Specification (Maven 3)
 

--- a/content/markdown/guides/mini/guide-naming-conventions.md
+++ b/content/markdown/guides/mini/guide-naming-conventions.md
@@ -1,3 +1,7 @@
+---
+title: Naming conventions of Maven coordinates (groupId, artifactId, and version)
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,10 +20,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-<head>
-   <title>Naming conventions of Maven coordinates (groupId, artifactId, and version)</title>
-</head>
 
 # Naming convention of Maven coordinates
 

--- a/content/markdown/repository/index.md
+++ b/content/markdown/repository/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Central Repository
+author:
+  - Brett Porter
+  - Hervé Boutemy
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -16,12 +23,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-<head>
-   <title>Maven Central Repository</title>
-   <meta name="author" content="Brett Porter" />
-   <meta name="author" content="Hervé Boutemy" />
-</head>
 
 # Maven Central Repository
 

--- a/content/markdown/scm.md
+++ b/content/markdown/scm.md
@@ -1,3 +1,8 @@
+---
+title: Source Repository
+author: Benjamin Bentmann
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Part of the breakage found in #1645. The five pages converted from xdoc in #621 kept their title and authors as a raw `<head>` block, which the Markdown parser does not honor — the metadata renders as stray text at the top of the page body, and every one of these pages ships with the bare `Maven` browser title. This moves the metadata to YAML front matter, the form the parser supports (same as `whatsnewinmaven4.md`).

Complementary to #1652, not overlapping: on `scm.md` this only adds the front matter and leaves the `<head>` removal and the `<object>` fix to that PR — the hunks don't touch, so the two merge in either order.

Verified: `mvn site` → all five pages carry their `<title>` and `<meta name="author">` again, and the stray body text is gone.

*This change was created with AI assistance.*