### PR TITLE
Fix structurally invalid HTML on the RM helper page

### DIFF
--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -24,7 +24,7 @@ select component category, then type artifact id and version to generate svn com
 <table>
 <tr><td>
 <a id="Component_category"></a>
-<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</output>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</p>
 <ul>
 <li><a href="?core">core</a></li>
 <li><a href="?shared">shared components</a></li>
@@ -42,7 +42,7 @@ select component category, then type artifact id and version to generate svn com
 
 </td><td>
 <a id="Component_information"></a>
-<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</output>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</p>
 
 <div>directory (~artifact id): <input type="text" name="artifactId" id="artifactId" style="vertical-align: baseline"/></div>
 <div>version: <input type="text" name="version" id="version" style="vertical-align: baseline"/></div>
@@ -53,7 +53,7 @@ select component category, then type artifact id and version to generate svn com
 
 <tr><td colspan="3">
 <a id="Instructions_to_publish_component_release_documentation"></a>
-<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</output>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</p>
 <pre id="svnmucc">svnmucc -m "Publish ${artifactId} ${version} documentation" \
   -U https://svn.apache.org/repos/asf/maven/website/components \
   cp HEAD ${category}-archives/${artifactId}-LATEST${vSuffix} ${category}-archives/${artifactId}-${version} \

--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -24,7 +24,7 @@ select component category, then type artifact id and version to generate svn com
 <table>
 <tr><td>
 <a id="Component_category"></a>
-<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</p>
+<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</output>
 <ul>
 <li><a href="?core">core</a></li>
 <li><a href="?shared">shared components</a></li>
@@ -42,7 +42,7 @@ select component category, then type artifact id and version to generate svn com
 
 </td><td>
 <a id="Component_information"></a>
-<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</p>
+<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</output>
 
 <div>directory (~artifact id): <input type="text" name="artifactId" id="artifactId" style="vertical-align: baseline"/></div>
 <div>version: <input type="text" name="version" id="version" style="vertical-align: baseline"/></div>
@@ -53,7 +53,7 @@ select component category, then type artifact id and version to generate svn com
 
 <tr><td colspan="3">
 <a id="Instructions_to_publish_component_release_documentation"></a>
-<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</p>
+<output role="heading" aria-level="3" style="display:block;margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</output>
 <pre id="svnmucc">svnmucc -m "Publish ${artifactId} ${version} documentation" \
   -U https://svn.apache.org/repos/asf/maven/website/components \
   cp HEAD ${category}-archives/${artifactId}-LATEST${vSuffix} ${category}-archives/${artifactId}-${version} \

--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -24,7 +24,7 @@ select component category, then type artifact id and version to generate svn com
 <table>
 <tr><td>
 <a id="Component_category"></a>
-<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</p>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</p>
 <ul>
 <li><a href="?core">core</a></li>
 <li><a href="?shared">shared components</a></li>
@@ -42,7 +42,7 @@ select component category, then type artifact id and version to generate svn com
 
 </td><td>
 <a id="Component_information"></a>
-<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</p>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</p>
 
 <div>directory (~artifact id): <input type="text" name="artifactId" id="artifactId" style="vertical-align: baseline"/></div>
 <div>version: <input type="text" name="version" id="version" style="vertical-align: baseline"/></div>
@@ -53,7 +53,7 @@ select component category, then type artifact id and version to generate svn com
 
 <tr><td colspan="3">
 <a id="Instructions_to_publish_component_release_documentation"></a>
-<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</p>
+<p style="margin:10px 0;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</p>
 <pre id="svnmucc">svnmucc -m "Publish ${artifactId} ${version} documentation" \
   -U https://svn.apache.org/repos/asf/maven/website/components \
   cp HEAD ${category}-archives/${artifactId}-LATEST${vSuffix} ${category}-archives/${artifactId}-${version} \

--- a/content/markdown/developers/website/component-reference-documentation-helper.md
+++ b/content/markdown/developers/website/component-reference-documentation-helper.md
@@ -23,7 +23,8 @@ select component category, then type artifact id and version to generate svn com
 
 <table>
 <tr><td>
-<h3>Component category</h3>
+<a id="Component_category"></a>
+<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component category</p>
 <ul>
 <li><a href="?core">core</a></li>
 <li><a href="?shared">shared components</a></li>
@@ -40,8 +41,8 @@ select component category, then type artifact id and version to generate svn com
 </ul>
 
 </td><td>
-
-<h3>Component information</h3>
+<a id="Component_information"></a>
+<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Component information</p>
 
 <div>directory (~artifact id): <input type="text" name="artifactId" id="artifactId" style="vertical-align: baseline"/></div>
 <div>version: <input type="text" name="version" id="version" style="vertical-align: baseline"/></div>
@@ -51,7 +52,8 @@ select component category, then type artifact id and version to generate svn com
 </td></tr>
 
 <tr><td colspan="3">
-<h3>Instructions to publish component release documentation</h3>
+<a id="Instructions_to_publish_component_release_documentation"></a>
+<p style="margin:10px 0;font-family:inherit;font-weight:bold;line-height:40px;color:inherit;font-size:24.5px;">Instructions to publish component release documentation</p>
 <pre id="svnmucc">svnmucc -m "Publish ${artifactId} ${version} documentation" \
   -U https://svn.apache.org/repos/asf/maven/website/components \
   cp HEAD ${category}-archives/${artifactId}-LATEST${vSuffix} ${category}-archives/${artifactId}-${version} \


### PR DESCRIPTION
Fixes structurally invalid HTML on the RM helper page found by an HTML-correctness sweep after apache/maven-site#1645: the three raw `<h3>` headings inside the component reference table each opened a Doxia section that only closes on the next heading, so `</td>`/`</tr>`/`</table>` closed over an open `<section>`. Browsers already repair this silently, so nothing was visibly broken — this is a cosmetic validity fix. But it's not just pedantry: the third section (`Instructions to publish...`) stayed open across the rest of the table, the closing `</table>`, and the entire `<script><![CDATA[...]]></script>` block, only closing right before `</main>` — a much bigger mis-nesting than the two `</td>` boundaries it's easiest to spot by eye.

The underlying limitation: Doxia opens and closes sections purely on heading (`<h1>`-`<h6>`) sink events, with no awareness of enclosing raw-HTML boundaries like `<td>`/`<tr>`/`<table>`. A heading physically cannot live inside a table cell without producing invalid nesting — this applies equally whether the heading was written as Markdown `###` or, as here, as literal HTML `<h3>`, since Doxia's HTML parser converts both into the same auto-sectioning event. That's a durable reason not to "simplify" this back to `<h3>` later; flagging as a possible future maven-doxia issue, not filing this session.

Fix: replaced each `<h3>` with an explicit `<a id="...">` (unchanged) followed by a `<p>` styled to match — a paragraph is a non-sectioning event, so it can't straddle a cell boundary. The inline style mirrors this skin's actual `h3` CSS rule (`apache-maven-fluido-2.1.0.min.css`), trimmed to the durable subset (`font-size`, `font-weight`, `line-height`, `margin`, `color:inherit`) since the skin exposes no reusable class for it — that's a decision for a reviewer to see, not magic numbers, and it does freeze today's skin values into this one page rather than tracking a future skin's real `<h3>`; acceptable for this single niche RM tool.

I also tried adding `role="heading" aria-level="3"` to keep the elements in the accessibility outline, but Doxia's paragraph sink only lets `class`/`id`/`lang`/`style`/`title` through its attribute allow-list (`SinkUtils.SINK_SECTION_ATTRIBUTES`) — ARIA attributes are silently dropped before they reach the page, confirmed by rebuilding and diffing the output. The only tags that skip that allow-list are ones Doxia's parser doesn't recognize at all, routed through its unfiltered `unknown()` sink event — which would mean reusing an unrelated HTML element (e.g. `<output>`, a form-associated element with its own implicit ARIA semantics) purely to smuggle attributes through, and coupling this page to the exact escape-hatch behavior the concurrent maven-doxia-converter#159 fix is touching. Not worth it for a niche internal page: this PR ships without the ARIA role, and the gap goes on the same future-upstream-issue list as the sectioning limitation above.

Verified: `mvn site`, then a Python `html.parser` stack-checker (implied closes allowed for li/p/td/th/tr/tbody/thead/dd/dt) on the built `component-reference-documentation-helper.html` → before: 9 tag-balance mismatches; after: zero, stack empty at EOF. Anchor `id` sets (19 total) and visible text (5259 chars, whitespace-normalized) are identical before and after. Confirmed every `id` the page's `<script>` calls `getElementById` on is still present and unchanged (`index-page`, `archives`, `artifactId`, `version`, `v4x`, `v4x-box`, `svnmucc`); `link-index-page` is looked up but was already unused/absent before this change, so that's pre-existing and out of scope here.

*This change was created with AI assistance.*
