### PR TITLE
add links to versions in archives

### DIFF
--- a/content/resources/extensions/components.links
+++ b/content/resources/extensions/components.links
@@ -1,3 +1,11 @@
 # links property file for Ant's symlink task in pom.xml:
-# links to components in https://maven.apache.org/components
+# links to components in https://maven.apache.org/components/extensions
 maven-build-cache-extension=../components/extensions/maven-build-cache-extension
+# links to archives in https://maven.apache.org/components/extensions-archives/
+maven-build-cache-extension-LATEST=../components/extensions-archives/maven-build-cache-extension-LATEST
+maven-build-cache-extension-1.1.0=../components/extensions-archives/maven-build-cache-extension-1.1.0
+maven-build-cache-extension-1.2.0=../components/extensions-archives/maven-build-cache-extension-1.2.0
+maven-build-cache-extension-1.2.1=../components/extensions-archives/maven-build-cache-extension-1.2.1
+maven-build-cache-extension-1.2.2=../components/extensions-archives/maven-build-cache-extension-1.2.2
+maven-build-cache-extension-1.2.3=../components/extensions-archives/maven-build-cache-extension-1.2.3
+maven-build-cache-extension-1.3.0=../components/extensions-archives/maven-build-cache-extension-1.3.0


### PR DESCRIPTION
test for easy version switching from current https://maven.apache.org/extensions/maven-build-cache-extension/
to other releases:
- https://maven.apache.org/extensions/maven-build-cache-extension-LATEST (that can be updated with SNAPSHOT site)
- previous releases like https://maven.apache.org/extensions/maven-build-cache-extension-1.2.3/
- or the current with a versioned URL: https://maven.apache.org/extensions/maven-build-cache-extension-1.3.0/

updating of the list of versions available in components in https://maven.apache.org/components/extensions-archives/ can be automated, to avoid manual maintenance when new releases are done

one key missing aspect is to suggest the list of available versions to the user: where to display that?
TBD

could be an option to solve some of the shortcomings described in #1647