### PR TITLE
Document the obfuscation-grade nature of Maven 3.x password encryption

### DIFF
--- a/content/markdown/guides/mini/guide-encryption.md
+++ b/content/markdown/guides/mini/guide-encryption.md
@@ -41,6 +41,8 @@ The implemented solution adds the following capabilities:
 - server entries in the `settings.xml` have passwords and/or keystore passphrases encrypted
   - for now - this is done via CLI **after** master password has been created and stored in appropriate location
 
+**Important:** The password encryption provided by Maven 3.x is *obfuscation-grade* (it relies on a single-hash key derivation and provides no authenticated encryption). It is useful to keep secrets out of logs and screenshots, but it will not resist a determined attacker with access to the encrypted values. It is not a substitute for proper secrets management: keep restrictive file permissions on your `settings.xml` (e.g. `chmod 600`), prefer a secrets vault or your CI/CD secret store, or move to [Maven 4](./guide-encryption-4.html) for stronger protection.
+
 ## How to create a master password
 
 Use the following command line:


### PR DESCRIPTION
Follow-up to the decision in apache/maven#12811.

Adds a short note to the Maven 3.x encryption guide (`content/markdown/guides/mini/guide-encryption.md`): the `settings.xml` password encryption is obfuscation-grade. It keeps secrets out of logs and screenshots, but don't rely on it against a determined attacker. Use restrictive file permissions on `settings.xml`, a secrets vault or CI secret store, or Maven 4 for stronger protection.

The Maven 4 guide (`guide-encryption-4.md`) is unchanged.