### PR TITLE
improve message in target svn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,27 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>10.0.0</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>pre-site</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
           <!-- no need for site:stage, use target/site -->
           <content>${project.reporting.outputDirectory}</content>
+          <!-- more informative messages in https://svn.apache.org/viewvc/maven/website/content/ -->
+          <checkinComment>${git.commit.id.describe} ${git.commit.message.short}</checkinComment>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
currently, https://svn.apache.org/viewvc/maven/website/content/ messages are always "Site checkin for project Apache Maven Site"

Git commit and message will be more informative (when we look at it, for example when svnpubsub seems stalled and we need to check)