### PR TITLE
Document the 256-character maximum version string length

### DIFF
--- a/content/markdown/guides/mini/guide-naming-conventions.md
+++ b/content/markdown/guides/mini/guide-naming-conventions.md
@@ -109,6 +109,18 @@ Examples
 2.3.4+15433
 ```
 
+### Maximum version length
+
+Version strings are limited to **256 characters**. This bound prevents
+pathological inputs from causing excessive resource consumption during
+version parsing: the recursive parser can nest one frame per separator,
+and digit runs beyond 18 characters are parsed into `BigInteger` at
+quadratic cost. The limit of 256 characters is far beyond any
+real-world version identifier (the longest versions observed on Maven
+Central are around 25 characters) while keeping the nesting depth and
+numeric items small. A version string that exceeds this limit will
+cause an `IllegalArgumentException` at parse time.
+
 ### Unstable versions (SNAPSHOT)
 
 `SNAPSHOT`s are artifacts built in between releases.


### PR DESCRIPTION
## Summary

- Documents the new 256-character limit on version strings in the naming conventions guide
- Explains why the limit exists (recursive parser nesting, quadratic BigInteger parsing)
- Notes that the longest real-world versions on Maven Central are ~25 characters

Follow-up to [apache/maven#12947](https://github.com/apache/maven/pull/12947) per [reviewer feedback](https://github.com/apache/maven/pull/12947#pullrequestreview-3022543825).

🤖 Generated with [Claude Code](https://claude.com/claude-code)