### PR TITLE
Skip table rows without a version column in Update

### DIFF
--- a/src/main/java/org/apache/maven/site/update/Update.java
+++ b/src/main/java/org/apache/maven/site/update/Update.java
@@ -80,6 +80,10 @@ public class Update {
         } else if (!Character.isDigit(version.charAt(0))) {
             // plugin index has an additional column (build or report)
             column++;
+            if (column >= cols.length) {
+                // not a release table row: no version column
+                return line;
+            }
             versionCol = cols[column];
             version = versionCol.trim();
         }


### PR DESCRIPTION
`mvn package -P update` (the `update-releases` workflow) fails with:

```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.6.3:java (update-releases)
        on project maven-site: An exception occurred while executing the Java class.
        Index 3 out of bounds for length 3
    at org.apache.maven.site.update.Update.update (Update.java:83)
```

`content/markdown/pom/index.md` now contains a second, two-column table whose rows also start with ``| [ ` `` , so `Update` treated them as release rows, assumed the extra build/report column of the plugin index and read past the end of the row.

Such rows are now skipped. Verified with `mvn package -P update`: all three index files are processed, `pom/index.md` release rows (ASF, Maven Parent POMs) are checked as expected, and the two-column table is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)